### PR TITLE
`General`: Auth Refinement for Usage without coursePhaseID

### DIFF
--- a/keycloakTokenVerifier/authMiddleware.go
+++ b/keycloakTokenVerifier/authMiddleware.go
@@ -39,6 +39,12 @@ func AuthenticationMiddleware(allowedRoles ...string) gin.HandlerFunc {
 			return
 		}
 
+		// This allows to use the middleware without coursePhaseID, if only PROMPT_Admin & PROMPT_Lecturer are allowed.
+		if onlyContainsAdminAndLecturer(allowedSet) {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "could not authenticate"})
+			return
+		}
+
 		// 2.) Check for Lecturer, Editor, or custom group roles.
 		if requiresLecturerOrCustom(allowedSet, allowedRoles) {
 			getLecturerAndEditorRole()(c)
@@ -162,4 +168,15 @@ func containsCustomRoleName(allowedRoles ...string) bool {
 	}
 
 	return false
+}
+
+// onlyContainsAdminAndLecturer returns true if the allowedSet only contains
+// "PROMPT_Admin" and/or "PROMPT_Lecturer".
+func onlyContainsAdminAndLecturer(allowedSet map[string]struct{}) bool {
+	for role := range allowedSet {
+		if role != "PROMPT_Admin" && role != "PROMPT_Lecturer" {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
This change allows to use the middleware without coursePhaseID, if only PROMPT_Admin & PROMPT_Lecturer are allowed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the authentication flow so that requests involving only specific roles now receive an immediate 401 Unauthorized response. This update provides clearer, more secure feedback when role-based access conditions aren’t met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->