### PR TITLE
`General`: Adjusting Keycloak Middleware to be accessible

### DIFF
--- a/keycloakTokenVerifier/authMiddleware.go
+++ b/keycloakTokenVerifier/authMiddleware.go
@@ -19,7 +19,7 @@ import (
 func AuthenticationMiddleware(allowedRoles ...string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Always run Keycloak middleware first.
-		keycloakMiddleware()(c)
+		KeycloakMiddleware()(c)
 		if c.IsAborted() {
 			return
 		}

--- a/keycloakTokenVerifier/keycloakMiddleware.go
+++ b/keycloakTokenVerifier/keycloakMiddleware.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Validates the token and extracts the claims from the token.
-func keycloakMiddleware() gin.HandlerFunc {
+func KeycloakMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tokenString, err := extractBearerToken(c)
 		if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -19,3 +19,7 @@ func DeferDBRollback(tx pgx.Tx, ctx context.Context) {
 func GetEnv(key, defaultValue string) string {
 	return utils.GetEnv(key, defaultValue)
 }
+
+func FetchJSON(url, authHeader string) ([]byte, error) {
+	return utils.FetchJSON(url, authHeader)
+}

--- a/utils/fetchJSON.go
+++ b/utils/fetchJSON.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// fetchJSON performs an HTTP GET request to the given URL with the auth header,
+// checks for a successful response, and returns the body.
+func FetchJSON(url, authHeader string) ([]byte, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := (&http.Client{
+		Timeout: 10 * time.Second,
+	}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received non-200 response: %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(resp.Body)
+}


### PR DESCRIPTION
At some endpoints (especially for Tease) you just want to validate if the token is valid, without checking the permission. Therefore, we need to export the keycloak middleware.