### PR TITLE
`Templating`: Add CopyRequest type for all servers to be able to copy phase-specific data

### DIFF
--- a/promptTypes/copyRequest.go
+++ b/promptTypes/copyRequest.go
@@ -1,8 +1,0 @@
-package promptTypes
-
-import "github.com/google/uuid"
-
-type CopyRequest struct {
-	SourceCoursePhaseID uuid.UUID `json:"sourceCoursePhaseID"`
-	TargetCoursePhaseID uuid.UUID `json:"targetCoursePhaseID"`
-}

--- a/promptTypes/copyRequest.go
+++ b/promptTypes/copyRequest.go
@@ -1,0 +1,8 @@
+package promptTypes
+
+import "github.com/google/uuid"
+
+type CopyRequest struct {
+	CoursePhaseIDOld uuid.UUID `json:"coursePhaseIDOld"`
+	CoursePhaseIDNew uuid.UUID `json:"coursePhaseIDNew"`
+}

--- a/promptTypes/copyRequest.go
+++ b/promptTypes/copyRequest.go
@@ -3,6 +3,6 @@ package promptTypes
 import "github.com/google/uuid"
 
 type CopyRequest struct {
-	CoursePhaseIDOld uuid.UUID `json:"coursePhaseIDOld"`
-	CoursePhaseIDNew uuid.UUID `json:"coursePhaseIDNew"`
+	SourceCoursePhaseID uuid.UUID `json:"sourceCoursePhaseID"`
+	TargetCoursePhaseID uuid.UUID `json:"targetCoursePhaseID"`
 }

--- a/promptTypes/phaseCopy.go
+++ b/promptTypes/phaseCopy.go
@@ -17,8 +17,8 @@ type PhaseCopyHandler interface {
 	HandlePhaseCopy(ctx context.Context, req PhaseCopyRequest) error
 }
 
-func RegisterCopyEndpoint(router *gin.RouterGroup, handler PhaseCopyHandler) {
-	router.POST("/copy", func(c *gin.Context) {
+func RegisterCopyEndpoint(router *gin.RouterGroup, authMiddleware gin.HandlerFunc, handler PhaseCopyHandler) {
+	router.POST("/copy", authMiddleware, func(c *gin.Context) {
 		var req PhaseCopyRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/promptTypes/phaseCopy.go
+++ b/promptTypes/phaseCopy.go
@@ -30,6 +30,6 @@ func RegisterCopyEndpoint(router *gin.RouterGroup, authMiddleware gin.HandlerFun
 			return
 		}
 
-		c.Status(http.StatusNoContent)
+		c.JSON(http.StatusOK, gin.H{"success": "Course phase copied successfully"})
 	})
 }

--- a/promptTypes/phaseCopy.go
+++ b/promptTypes/phaseCopy.go
@@ -1,0 +1,35 @@
+package promptTypes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type PhaseCopyRequest struct {
+	SourceCoursePhaseID uuid.UUID `json:"sourceCoursePhaseID"`
+	TargetCoursePhaseID uuid.UUID `json:"targetCoursePhaseID"`
+}
+
+type PhaseCopyHandler interface {
+	HandlePhaseCopy(ctx context.Context, req PhaseCopyRequest) error
+}
+
+func RegisterCopyEndpoint(router *gin.RouterGroup, handler PhaseCopyHandler) {
+	router.POST("/copy", func(c *gin.Context) {
+		var req PhaseCopyRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		if err := handler.HandlePhaseCopy(c.Request.Context(), req); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.Status(http.StatusNoContent)
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to support copying phases between courses. Users can initiate a copy operation by providing source and target phase identifiers. The endpoint returns appropriate error messages for invalid requests and confirms successful operations with a success message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->