### PR TITLE
Support non keycloak students in subject identifiers and adjust deletion route to directly take the handler function

### DIFF
--- a/keycloakTokenVerifier/keycloakCoreRequests/subjectIdentifiers.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/subjectIdentifiers.go
@@ -7,20 +7,27 @@ import "github.com/google/uuid"
 // so that each microservice can scope its export or deletion to exactly one subject
 // without performing additional lookups.
 //
-// There are two kinds of subjects:
+// There are three kinds of subjects:
 //
-//   - Student: a person who participates in courses. All fields are populated —
-//     StudentID and CourseParticipationIDs are
-//     guaranteed to be non-empty and should be used to scope data access.
+//   - Student with a Keycloak account: all fields are populated. StudentID and
+//     CourseParticipationIDs should be used to scope data access; UserID can be
+//     used for any user-account-scoped data (e.g. instructor-note authorship).
+//
+//   - Student without a Keycloak account: UserID is uuid.Nil. StudentID and
+//     CourseParticipationIDs are populated and should be used to scope data access.
+//     Skip any user-account-scoped operations.
 //
 //   - Platform user: a person with a platform role such as lecturer, course editor,
-//     or administrator who has no student record. Only UserID is guaranteed to be
-//     set. Microservices should check StudentID == uuid.Nil to detect this case
+//     or administrator who has no student record. Only UserID is set; StudentID is
+//     uuid.Nil. Microservices should check StudentID == uuid.Nil to detect this case
 //     and limit their scope to user-level data only.
+//
+// At least one of UserID and StudentID is always set; both being uuid.Nil is invalid.
 type SubjectIdentifiers struct {
 	// UserID is the platform-wide unique identifier of the user account.
-	// Always present regardless of subject type.
-	UserID uuid.UUID `json:"userID" binding:"required"`
+	// uuid.Nil indicates a student without a Keycloak account; downstream services
+	// should skip user-account-scoped operations in that case.
+	UserID uuid.UUID `json:"userID"`
 
 	// StudentID is the unique identifier of the student record.
 	// Only set for student subjects — uuid.Nil indicates a platform user with no student record.


### PR DESCRIPTION
The PR makes the user_id optional in subject identifiers.

This refelect reality more accurately, as there are students on the prompt platform that do not have a corresponding keycloak account.

originally this was not considered as only logged in users were able to request an export and deletion, therefore implying a keycloak account

With the latest changes in deletion, admins can request deletions for any student, including those without a keycloak id. This change makes sense.

Also generally speaking all CPMs should support non keycloak students anywas, as they also have the gdpr rights.

This can be merged and version bumped right away, as no cpm is reading or using the user_id until now anyways.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for different user identification scenarios, including users with and without linked accounts.
  * Improved handling for privacy-related data deletion requests.

* **Bug Fixes**
  * Relaxed a required user identifier constraint so valid requests can be processed more flexibly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->