### PR TITLE
Deletion Endpoint Remove legacy interface and directly take handler function, as in export

### DIFF
--- a/promptTypes/privacyDeletion.go
+++ b/promptTypes/privacyDeletion.go
@@ -14,21 +14,16 @@ type PrivacyDeletionRequest struct {
 	SubjectIdentifiers keycloakTokenVerifier.SubjectIdentifiers `json:"subjectIdentifiers"`
 }
 
-// A microservice should provide a PrivacyDataDeletionHandler. When a request for deletion
-// comes in, the endpoint registered with (RegisterPrivacyDataDeletionEndpoint) will handle
-// authentication and validation and then call the HandlePrivacyDeleteData of the handler
-// The HandlePrivacyDeleteData function is the main function which should delete all data
-// related to the subject identified by the SubjectIdentifiers. Returning no error indicates
-// success.
+// PrivacyDataDeletionHandler is called by the SDK when a privacy deletion request comes in.
+// The implementation should delete all data related to the subject identified by the
+// SubjectIdentifiers. Returning no error indicates success.
 //
 // Example:
 //
 //		func(c *gin.Context, subject keycloakTokenVerifier.SubjectIdentifiers) error {
 //	     return someService.DeleteUser(c, subject.UserID)
 //		}
-type PrivacyDataDeletionHandler interface {
-	HandlePrivacyDeleteData(c *gin.Context, subject keycloakTokenVerifier.SubjectIdentifiers) error
-}
+type PrivacyDataDeletionHandler func(c *gin.Context, subject keycloakTokenVerifier.SubjectIdentifiers) error
 
 // RegisterPrivacyDataDeletionEndpoint registers the standardized POST endpoint for privacy
 // deletion requests. The core server calls this endpoint with an admin token on each microservice
@@ -51,7 +46,7 @@ func RegisterPrivacyDataDeletionEndpoint(router *gin.RouterGroup, handler Privac
 			return
 		}
 
-		if err := handler.HandlePrivacyDeleteData(c, req.SubjectIdentifiers); err != nil {
+		if err := handler(c, req.SubjectIdentifiers); err != nil {
 			logrus.Error("deletion was not successful, error: ", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to process deletion"})
 			return


### PR DESCRIPTION
the deletion handler is still 'hidden' inside an interface for legacy reasons.

The RegisterPrivacyDataDeletionHandler now direclt accepts the handler function as an argument.

As previously, this handler function is called when the CPM receives a call to delete all subject data


needed for https://github.com/prompt-edu/prompt/pull/1680
and all cpm implementationts.
part of https://github.com/orgs/prompt-edu/discussions/683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the privacy deletion handler API, making endpoint handling more direct and consistent.
  * Updated the related example/documentation to match the new handler format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->