### PR TITLE
Add discord notification workflow

### DIFF
--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -1,0 +1,28 @@
+name: Discord PR Notification
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    if: github.event.label.name == 'schau mi o'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord Notification
+        uses: appleboy/discord-action@v1.2.0
+        with:
+          webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          username: "PROMPT Review Bot"
+          avatar_url: "https://prompt.aet.cit.tum.de/img/prompt_logo.svg"
+          message: |
+            🚀 **New Review Request!**
+            
+            **PR:** [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})
+            **Author:** ${{ github.event.pull_request.user.login }}
+            
+            @Maintainers, please have a look! (schau mi o! 😉)


### PR DESCRIPTION
This PR adds the same discord notification workflow for PRs that receive the label 'schau mi o'

For this to work, we would need to copy over / config the DISCORD_WEBHOOK_ID and DISCORD_WEBHOOK_TOKEN env vars (or configure as org level secret)