### PR TITLE
Fix cross-course access control fail-open (GHSA-4wgm-2wvm-fphm)

### DIFF
--- a/keycloakTokenVerifier/getIsStudent.go
+++ b/keycloakTokenVerifier/getIsStudent.go
@@ -10,7 +10,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Important: This requires a CoursePhaseID as a parameter.
+// isStudentOfCoursePhaseMiddleware verifies with core that the caller is a
+// student of the course phase named by the coursePhaseID path parameter. On a
+// denial it fails closed by clearing the student flags on both the gin context
+// and the TokenUser; any unexpected error aborts the request with 500.
 func isStudentOfCoursePhaseMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		coursePhaseID, err := uuid.Parse(c.Param("coursePhaseID"))

--- a/keycloakTokenVerifier/getIsStudent.go
+++ b/keycloakTokenVerifier/getIsStudent.go
@@ -30,7 +30,7 @@ func isStudentOfCoursePhaseMiddleware() gin.HandlerFunc {
 		// request from the core if the user is a student of the course phase
 		isStudentResponse, err := keycloakCoreRequests.SendIsStudentRequest(KeycloakTokenVerifierSingleton.CoreURL, c.GetHeader("Authorization"), coursePhaseID)
 		if err != nil {
-			if err.Error() == "not student of course" {
+			if errors.Is(err, keycloakCoreRequests.ErrNotStudentOfCourse) {
 				// Core denied access (403/401): the caller is not a student of this
 				// course phase. Fail closed on both the context keys and the token user.
 				c.Set("isStudentOfCourse", false)
@@ -42,7 +42,7 @@ func isStudentOfCoursePhaseMiddleware() gin.HandlerFunc {
 					SetTokenUser(c, tokenUser)
 				}
 			} else {
-				log.Error("Error getting course roles:", err)
+				log.Error("Error verifying course phase participation:", err)
 				_ = c.AbortWithError(http.StatusInternalServerError, err)
 				return
 			}

--- a/keycloakTokenVerifier/getIsStudent.go
+++ b/keycloakTokenVerifier/getIsStudent.go
@@ -31,15 +31,24 @@ func isStudentOfCoursePhaseMiddleware() gin.HandlerFunc {
 		isStudentResponse, err := keycloakCoreRequests.SendIsStudentRequest(KeycloakTokenVerifierSingleton.CoreURL, c.GetHeader("Authorization"), coursePhaseID)
 		if err != nil {
 			if err.Error() == "not student of course" {
+				// Core denied access (403/401): the caller is not a student of this
+				// course phase. Fail closed on both the context keys and the token user.
 				c.Set("isStudentOfCourse", false)
 				c.Set("isStudentOfCoursePhase", false)
+
+				if tokenUser, ok := GetTokenUser(c); ok {
+					tokenUser.IsStudentOfCourse = false
+					tokenUser.IsStudentOfCoursePhase = false
+					SetTokenUser(c, tokenUser)
+				}
 			} else {
 				log.Error("Error getting course roles:", err)
 				_ = c.AbortWithError(http.StatusInternalServerError, err)
 				return
 			}
 		} else {
-			// DEPRECATED: Keep this for backwards compatibility
+			// Reaching here means core returned 200, which it only does after
+			// authorizing the caller as a student of this phase's course.
 			c.Set("isStudentOfCourse", true)
 			c.Set("isStudentOfCoursePhase", isStudentResponse.IsStudentOfCoursePhase)
 			c.Set("courseParticipationID", isStudentResponse.CourseParticipationID)

--- a/keycloakTokenVerifier/getIsStudent_test.go
+++ b/keycloakTokenVerifier/getIsStudent_test.go
@@ -45,6 +45,8 @@ func newStudentPathRouter(t *testing.T, coreURL string) *gin.Engine {
 	return r
 }
 
+// newCoreStub returns an httptest server that answers every request with the
+// given status and body, standing in for core's is_student endpoint.
 func newCoreStub(status int, body string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(status)

--- a/keycloakTokenVerifier/getIsStudent_test.go
+++ b/keycloakTokenVerifier/getIsStudent_test.go
@@ -24,7 +24,9 @@ func newStudentPathRouter(t *testing.T, coreURL string) *gin.Engine {
 
 	u, err := url.Parse(coreURL)
 	require.NoError(t, err)
+	prev := KeycloakTokenVerifierSingleton
 	KeycloakTokenVerifierSingleton = &KeycloakTokenVerifier{CoreURL: *u}
+	t.Cleanup(func() { KeycloakTokenVerifierSingleton = prev })
 
 	r := gin.New()
 	grp := r.Group("/api/course_phase/:coursePhaseID")

--- a/keycloakTokenVerifier/getIsStudent_test.go
+++ b/keycloakTokenVerifier/getIsStudent_test.go
@@ -1,0 +1,122 @@
+package keycloakTokenVerifier
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newStudentPathRouter wires the student-verification middleware exactly as
+// AuthenticationMiddleware does, but without KeycloakMiddleware (which needs a
+// live OIDC verifier). A pre-middleware seeds the TokenUser the way Keycloak
+// would, and the terminal handler echoes the gate-relevant flags so the test
+// can assert them. authMiddleware.go step 3 grants student access on
+// TokenUser.IsStudentOfCourse, so that flag is what guards the CVE.
+func newStudentPathRouter(t *testing.T, coreURL string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	u, err := url.Parse(coreURL)
+	require.NoError(t, err)
+	KeycloakTokenVerifierSingleton = &KeycloakTokenVerifier{CoreURL: *u}
+
+	r := gin.New()
+	grp := r.Group("/api/course_phase/:coursePhaseID")
+	grp.GET("/resource",
+		func(c *gin.Context) {
+			SetTokenUser(c, TokenUser{Roles: map[string]bool{}})
+			c.Next()
+		},
+		isStudentOfCoursePhaseMiddleware(),
+		func(c *gin.Context) {
+			tu, _ := GetTokenUser(c)
+			c.JSON(http.StatusOK, gin.H{
+				"isStudentOfCourse":      tu.IsStudentOfCourse,
+				"isStudentOfCoursePhase": tu.IsStudentOfCoursePhase,
+			})
+		},
+	)
+	return r
+}
+
+func newCoreStub(status int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		if body != "" {
+			_, _ = w.Write([]byte(body))
+		}
+	}))
+}
+
+// TestStudentPath_CrossCourseDenied is the regression guard for
+// GHSA-4wgm-2wvm-fphm: when core denies cross-course access with 403, the
+// student-verification middleware must leave IsStudentOfCourse false so the
+// auth gate denies the request. Before the fix, a 403 was silently treated as
+// success and IsStudentOfCourse was hardcoded to true.
+func TestStudentPath_CrossCourseDenied(t *testing.T) {
+	core := newCoreStub(http.StatusForbidden, `{"error":"no matching permission found"}`)
+	defer core.Close()
+
+	router := newStudentPathRouter(t, core.URL)
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/course_phase/11111111-1111-1111-1111-111111111111/resource", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var body struct {
+		IsStudentOfCourse      bool `json:"isStudentOfCourse"`
+		IsStudentOfCoursePhase bool `json:"isStudentOfCoursePhase"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	assert.False(t, body.IsStudentOfCourse, "cross-course actor must not be a student of the course")
+	assert.False(t, body.IsStudentOfCoursePhase)
+}
+
+// TestStudentPath_SameCourseAllowed ensures legitimate same-course students are
+// unaffected: core returns 200 and the flags are populated from the response.
+func TestStudentPath_SameCourseAllowed(t *testing.T) {
+	core := newCoreStub(http.StatusOK, `{"isStudentOfCoursePhase":true,"courseParticipationID":"00000000-0000-0000-0000-000000000001"}`)
+	defer core.Close()
+
+	router := newStudentPathRouter(t, core.URL)
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/course_phase/11111111-1111-1111-1111-111111111111/resource", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var body struct {
+		IsStudentOfCourse      bool `json:"isStudentOfCourse"`
+		IsStudentOfCoursePhase bool `json:"isStudentOfCoursePhase"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	assert.True(t, body.IsStudentOfCourse)
+	assert.True(t, body.IsStudentOfCoursePhase)
+}
+
+// TestStudentPath_UnexpectedCoreStatusFailsClosed ensures an unexpected core
+// status aborts with 500 rather than proceeding to the handler.
+func TestStudentPath_UnexpectedCoreStatusFailsClosed(t *testing.T) {
+	core := newCoreStub(http.StatusInternalServerError, "")
+	defer core.Close()
+
+	router := newStudentPathRouter(t, core.URL)
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/course_phase/11111111-1111-1111-1111-111111111111/resource", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+}

--- a/keycloakTokenVerifier/getLecturerAndEditorRole.go
+++ b/keycloakTokenVerifier/getLecturerAndEditorRole.go
@@ -30,6 +30,10 @@ func getLecturerAndEditorRole() gin.HandlerFunc {
 		// retrieve the relevant roles from the core
 		tokenMapping, err := keycloakCoreRequests.SendCoursePhaseRoleMappingRequest(KeycloakTokenVerifierSingleton.CoreURL, c.GetHeader("Authorization"), coursePhaseID)
 		if err != nil {
+			if errors.Is(err, keycloakCoreRequests.ErrUnauthenticated) {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "could not authenticate"})
+				return
+			}
 			log.Error("Error getting course roles:", err)
 			_ = c.AbortWithError(http.StatusInternalServerError, err)
 			return

--- a/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping.go
@@ -2,6 +2,7 @@ package keycloakCoreRequests
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"path"
@@ -24,9 +25,11 @@ func SendCoursePhaseRoleMappingRequest(coreURL url.URL, authHeader string, cours
 		}
 	}()
 
+	// Fail closed: an empty role mapping would leave CustomRolePrefix unset, causing
+	// the custom-role check in the auth middleware to match un-prefixed roles.
 	if resp.StatusCode != http.StatusOK {
 		log.Error("Received non-OK response:", resp.Status)
-		return keycloakTokenVerifierDTO.GetCourseRoles{}, nil
+		return keycloakTokenVerifierDTO.GetCourseRoles{}, fmt.Errorf("unexpected core response: %s", resp.Status)
 	}
 
 	var authResponse keycloakTokenVerifierDTO.GetCourseRoles

--- a/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping.go
@@ -12,6 +12,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// SendCoursePhaseRoleMappingRequest fetches the lecturer/editor/custom role
+// mapping for the given course phase from core. It fails closed by returning an
+// error on any non-200 status, so callers never receive an empty mapping that
+// could weaken the custom-role check in the auth middleware.
 func SendCoursePhaseRoleMappingRequest(coreURL url.URL, authHeader string, coursePhaseID uuid.UUID) (keycloakTokenVerifierDTO.GetCourseRoles, error) {
 	path := path.Join("/api/auth/course_phase", coursePhaseID.String(), "roles")
 

--- a/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping.go
@@ -2,6 +2,7 @@ package keycloakCoreRequests
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -11,6 +12,10 @@ import (
 	"github.com/prompt-edu/prompt-sdk/keycloakTokenVerifier/keycloakTokenVerifierDTO"
 	log "github.com/sirupsen/logrus"
 )
+
+// ErrUnauthenticated is returned when core rejects the request as
+// unauthenticated (401), e.g. for an expired or invalid token.
+var ErrUnauthenticated = errors.New("unauthenticated")
 
 // SendCoursePhaseRoleMappingRequest fetches the lecturer/editor/custom role
 // mapping for the given course phase from core. It fails closed by returning an
@@ -28,6 +33,11 @@ func SendCoursePhaseRoleMappingRequest(coreURL url.URL, authHeader string, cours
 			log.Error("failed to close response body:", closeErr)
 		}
 	}()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		log.Info("Unauthenticated core response for role mapping")
+		return keycloakTokenVerifierDTO.GetCourseRoles{}, ErrUnauthenticated
+	}
 
 	// Fail closed: an empty role mapping would leave CustomRolePrefix unset, causing
 	// the custom-role check in the auth middleware to match un-prefixed roles.

--- a/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping_test.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping_test.go
@@ -1,0 +1,67 @@
+package keycloakCoreRequests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendCoursePhaseRoleMappingRequest_StatusMapping(t *testing.T) {
+	tests := []struct {
+		name        string
+		coreStatus  int
+		coreBody    string
+		wantErr     bool
+		wantPrefix  string
+	}{
+		{
+			name:       "200 returns role mapping",
+			coreStatus: http.StatusOK,
+			coreBody:   `{"courseLecturerRole":"WS24-Test-Lecturer","courseEditorRole":"WS24-Test-Editor","customRolePrefix":"WS24-Test-cg-"}`,
+			wantErr:    false,
+			wantPrefix: "WS24-Test-cg-",
+		},
+		{
+			// Fail closed: a 403 must not yield an empty mapping (empty CustomRolePrefix
+			// would let the auth middleware match un-prefixed custom roles).
+			name:       "403 fails closed",
+			coreStatus: http.StatusForbidden,
+			wantErr:    true,
+		},
+		{
+			name:       "500 fails closed",
+			coreStatus: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.coreStatus)
+				if tt.coreBody != "" {
+					_, _ = w.Write([]byte(tt.coreBody))
+				}
+			}))
+			defer server.Close()
+
+			coreURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			resp, err := SendCoursePhaseRoleMappingRequest(*coreURL, "Bearer token", uuid.New())
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Empty(t, resp.CustomRolePrefix)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantPrefix, resp.CustomRolePrefix)
+			}
+		})
+	}
+}

--- a/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping_test.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping_test.go
@@ -16,11 +16,12 @@ import (
 // empty CustomRolePrefix rather than a silent success.
 func TestSendCoursePhaseRoleMappingRequest_StatusMapping(t *testing.T) {
 	tests := []struct {
-		name        string
-		coreStatus  int
-		coreBody    string
-		wantErr     bool
-		wantPrefix  string
+		name       string
+		coreStatus int
+		coreBody   string
+		wantErr    bool
+		wantErrIs  error
+		wantPrefix string
 	}{
 		{
 			name:       "200 returns role mapping",
@@ -35,6 +36,12 @@ func TestSendCoursePhaseRoleMappingRequest_StatusMapping(t *testing.T) {
 			name:       "403 fails closed",
 			coreStatus: http.StatusForbidden,
 			wantErr:    true,
+		},
+		{
+			name:       "401 maps to ErrUnauthenticated",
+			coreStatus: http.StatusUnauthorized,
+			wantErr:    true,
+			wantErrIs:  ErrUnauthenticated,
 		},
 		{
 			name:       "500 fails closed",
@@ -60,6 +67,9 @@ func TestSendCoursePhaseRoleMappingRequest_StatusMapping(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
+				if tt.wantErrIs != nil {
+					assert.ErrorIs(t, err, tt.wantErrIs)
+				}
 				assert.Empty(t, resp.CustomRolePrefix)
 			} else {
 				require.NoError(t, err)

--- a/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping_test.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/coursePhaseRoleMapping_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestSendCoursePhaseRoleMappingRequest_StatusMapping asserts the request fails
+// closed: 200 yields the role mapping, while any non-200 returns an error and an
+// empty CustomRolePrefix rather than a silent success.
 func TestSendCoursePhaseRoleMappingRequest_StatusMapping(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/keycloakTokenVerifier/keycloakCoreRequests/isStudent.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/isStudent.go
@@ -3,6 +3,7 @@ package keycloakCoreRequests
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"path"
@@ -25,14 +26,16 @@ func SendIsStudentRequest(coreURL url.URL, authHeader string, coursePhaseID uuid
 		}
 	}()
 
-	if resp.StatusCode == http.StatusUnauthorized {
+	// Core denies cross-course/cross-phase access with 403 (and 401 if unauthenticated).
+	// Both mean "not a student of this course phase" and must fail closed.
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		log.Info("Not student of course")
 		return keycloakTokenVerifierDTO.GetCoursePhaseParticipation{IsStudentOfCoursePhase: false}, errors.New("not student of course")
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		log.Error("Received non-OK response:", resp.Status)
-		return keycloakTokenVerifierDTO.GetCoursePhaseParticipation{}, nil
+		return keycloakTokenVerifierDTO.GetCoursePhaseParticipation{}, fmt.Errorf("unexpected core response: %s", resp.Status)
 	}
 
 	var isStudentResponse keycloakTokenVerifierDTO.GetCoursePhaseParticipation

--- a/keycloakTokenVerifier/keycloakCoreRequests/isStudent.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/isStudent.go
@@ -19,7 +19,7 @@ var ErrNotStudentOfCourse = errors.New("not student of course")
 
 // SendIsStudentRequest asks core whether the bearer of authHeader is a student
 // of the given course phase. It returns ErrNotStudentOfCourse when core denies
-// access (401/403), a wrapped error for any other non-200 status, and the
+// access (401/403), a descriptive error for any other non-200 status, and the
 // decoded participation on 200.
 func SendIsStudentRequest(coreURL url.URL, authHeader string, coursePhaseID uuid.UUID) (keycloakTokenVerifierDTO.GetCoursePhaseParticipation, error) {
 	path := path.Join("/api/auth/course_phase", coursePhaseID.String(), "is_student")

--- a/keycloakTokenVerifier/keycloakCoreRequests/isStudent.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/isStudent.go
@@ -13,6 +13,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// ErrNotStudentOfCourse is returned when core denies course-phase access (401/403).
+// Callers must compare with errors.Is rather than matching the message string.
+var ErrNotStudentOfCourse = errors.New("not student of course")
+
 func SendIsStudentRequest(coreURL url.URL, authHeader string, coursePhaseID uuid.UUID) (keycloakTokenVerifierDTO.GetCoursePhaseParticipation, error) {
 	path := path.Join("/api/auth/course_phase", coursePhaseID.String(), "is_student")
 
@@ -30,7 +34,7 @@ func SendIsStudentRequest(coreURL url.URL, authHeader string, coursePhaseID uuid
 	// Both mean "not a student of this course phase" and must fail closed.
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		log.Info("Not student of course")
-		return keycloakTokenVerifierDTO.GetCoursePhaseParticipation{IsStudentOfCoursePhase: false}, errors.New("not student of course")
+		return keycloakTokenVerifierDTO.GetCoursePhaseParticipation{IsStudentOfCoursePhase: false}, ErrNotStudentOfCourse
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/keycloakTokenVerifier/keycloakCoreRequests/isStudent.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/isStudent.go
@@ -17,6 +17,10 @@ import (
 // Callers must compare with errors.Is rather than matching the message string.
 var ErrNotStudentOfCourse = errors.New("not student of course")
 
+// SendIsStudentRequest asks core whether the bearer of authHeader is a student
+// of the given course phase. It returns ErrNotStudentOfCourse when core denies
+// access (401/403), a wrapped error for any other non-200 status, and the
+// decoded participation on 200.
 func SendIsStudentRequest(coreURL url.URL, authHeader string, coursePhaseID uuid.UUID) (keycloakTokenVerifierDTO.GetCoursePhaseParticipation, error) {
 	path := path.Join("/api/auth/course_phase", coursePhaseID.String(), "is_student")
 

--- a/keycloakTokenVerifier/keycloakCoreRequests/isStudent_test.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/isStudent_test.go
@@ -1,0 +1,77 @@
+package keycloakCoreRequests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendIsStudentRequest_StatusMapping(t *testing.T) {
+	tests := []struct {
+		name              string
+		coreStatus        int
+		coreBody          string
+		wantErr           bool
+		wantErrMsg        string
+		wantStudentOfPhase bool
+	}{
+		{
+			name:               "200 authorized",
+			coreStatus:         http.StatusOK,
+			coreBody:           `{"isStudentOfCoursePhase":true,"courseParticipationID":"00000000-0000-0000-0000-000000000001"}`,
+			wantErr:            false,
+			wantStudentOfPhase: true,
+		},
+		{
+			name:       "401 unauthenticated fails closed",
+			coreStatus: http.StatusUnauthorized,
+			wantErr:    true,
+			wantErrMsg: "not student of course",
+		},
+		{
+			// Regression guard for GHSA-4wgm-2wvm-fphm: core denies cross-course
+			// access with 403, which must map to "not student of course".
+			name:       "403 cross-course fails closed",
+			coreStatus: http.StatusForbidden,
+			coreBody:   `{"error":"no matching permission found"}`,
+			wantErr:    true,
+			wantErrMsg: "not student of course",
+		},
+		{
+			name:       "500 unexpected returns hard error",
+			coreStatus: http.StatusInternalServerError,
+			wantErr:    true,
+			wantErrMsg: "unexpected core response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.coreStatus)
+				if tt.coreBody != "" {
+					_, _ = w.Write([]byte(tt.coreBody))
+				}
+			}))
+			defer server.Close()
+
+			coreURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			resp, err := SendIsStudentRequest(*coreURL, "Bearer token", uuid.New())
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantStudentOfPhase, resp.IsStudentOfCoursePhase)
+		})
+	}
+}

--- a/keycloakTokenVerifier/keycloakCoreRequests/isStudent_test.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/isStudent_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestSendIsStudentRequest_StatusMapping asserts the status-to-result mapping:
+// 200 authorizes, 401/403 map to ErrNotStudentOfCourse, and any other non-200
+// returns a hard error so the middleware fails closed.
 func TestSendIsStudentRequest_StatusMapping(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/keycloakTokenVerifier/keycloakCoreRequests/isStudent_test.go
+++ b/keycloakTokenVerifier/keycloakCoreRequests/isStudent_test.go
@@ -1,6 +1,7 @@
 package keycloakCoreRequests
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,11 +14,12 @@ import (
 
 func TestSendIsStudentRequest_StatusMapping(t *testing.T) {
 	tests := []struct {
-		name              string
-		coreStatus        int
-		coreBody          string
-		wantErr           bool
-		wantErrMsg        string
+		name               string
+		coreStatus         int
+		coreBody           string
+		wantErr            bool
+		wantErrMsg         string
+		wantNotStudent     bool
 		wantStudentOfPhase bool
 	}{
 		{
@@ -28,19 +30,21 @@ func TestSendIsStudentRequest_StatusMapping(t *testing.T) {
 			wantStudentOfPhase: true,
 		},
 		{
-			name:       "401 unauthenticated fails closed",
-			coreStatus: http.StatusUnauthorized,
-			wantErr:    true,
-			wantErrMsg: "not student of course",
+			name:           "401 unauthenticated fails closed",
+			coreStatus:     http.StatusUnauthorized,
+			wantErr:        true,
+			wantErrMsg:     "not student of course",
+			wantNotStudent: true,
 		},
 		{
 			// Regression guard for GHSA-4wgm-2wvm-fphm: core denies cross-course
-			// access with 403, which must map to "not student of course".
-			name:       "403 cross-course fails closed",
-			coreStatus: http.StatusForbidden,
-			coreBody:   `{"error":"no matching permission found"}`,
-			wantErr:    true,
-			wantErrMsg: "not student of course",
+			// access with 403, which must map to ErrNotStudentOfCourse.
+			name:           "403 cross-course fails closed",
+			coreStatus:     http.StatusForbidden,
+			coreBody:       `{"error":"no matching permission found"}`,
+			wantErr:        true,
+			wantErrMsg:     "not student of course",
+			wantNotStudent: true,
 		},
 		{
 			name:       "500 unexpected returns hard error",
@@ -68,6 +72,7 @@ func TestSendIsStudentRequest_StatusMapping(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				assert.Equal(t, tt.wantNotStudent, errors.Is(err, ErrNotStudentOfCourse))
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
## Summary

Fixes the cross-course broken access control reported in advisory **GHSA-4wgm-2wvm-fphm** (BOLA/IDOR, CWE-639 / CWE-285). A student enrolled only in course A could reach course B's phase endpoints (assessment, certificate, team-allocation, self-team-allocation, ...) and receive HTTP 200.

Core authorizes correctly (returns **403** for cross-course access). The defect was a **fail-open in this SDK's student-verification path**:

- `SendIsStudentRequest` returned an empty struct with a **nil error** on any non-200 status. Core's 403 fell through this path.
- Because the error was nil, `isStudentOfCoursePhaseMiddleware` took the success branch and **hardcoded** `IsStudentOfCourse = true`, so the auth gate called `c.Next()`.

All the leaking endpoints include `Student` in their allowed-role set, so they all funnel through this one path - fixing it closes all of them.

## Changes

- **`keycloakCoreRequests/isStudent.go`** - map both `401` and `403` to the `"not student of course"` sentinel; any other non-200 now returns a real error (`unexpected core response: ...`) so the middleware aborts 500 instead of proceeding.
- **`keycloakTokenVerifier/getIsStudent.go`** - derive membership from the core response instead of hardcoding `true`; on denial, also clear `IsStudentOfCourse` / `IsStudentOfCoursePhase` on the `TokenUser`.
- **`keycloakCoreRequests/coursePhaseRoleMapping.go`** - fail closed on non-200 (an empty `CustomRolePrefix` would let the custom-role check match un-prefixed roles - same fail-open family, latent bypass).
- **Regression tests** (`httptest`-backed, no testcontainers): table tests over `200/401/403/500` for both core requests, plus a middleware-level test driving `isStudentOfCoursePhaseMiddleware`. The **403 cross-course case is the CVE guard**.

Scope is intentionally minimal: course-level semantics are preserved (the gate still grants on `IsStudentOfCourse`), which is now correctly `false` for cross-course actors. No new phase-level gating was introduced.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./keycloakTokenVerifier/...` green (new 403 cases pass, existing helper tests unaffected)
- [x] Live end-to-end against a running stack: unpatched reproduced course-B `200`; patched returns `401` on cross-course while same-course still returns `200`
- [ ] Reviewer confirms consuming services should bump to the release cut from this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Student/course-phase eligibility now “fails closed” more reliably when the service can’t confirm status, preventing incorrect eligibility flags from being set.
  * Core response handling is more consistent: forbidden/unauthenticated and unexpected statuses no longer get treated as successful lookups.
  * Role and student-status retrieval now returns errors on non-success responses instead of returning empty results.
* **Tests**
  * Added and expanded unit/regression tests for same-course success, cross-course denial, and unexpected core response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
