### PR TITLE
Add `TutorScopingMiddleware` for reusable tutor team access control

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -2,6 +2,7 @@ package promptSDK
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/prompt-edu/prompt-sdk/keycloakTokenVerifier"
 )
 
@@ -24,4 +25,19 @@ func AuthenticationMiddleware(allowedRoles ...string) gin.HandlerFunc {
 
 func SubjectIdentifierMiddleware() gin.HandlerFunc {
 	return keycloakTokenVerifier.SubjectIdentifierMiddleware()
+}
+
+// TutorTeamResolver is implemented by each service against its own database to
+// resolve which team a tutor (CourseEditor) is assigned to.
+type TutorTeamResolver = keycloakTokenVerifier.TutorTeamResolver
+
+// TutorTeamIDKey is the gin context key under which the resolved tutor team ID is stored.
+const TutorTeamIDKey = keycloakTokenVerifier.TutorTeamIDKey
+
+func TutorScopingMiddleware(resolver TutorTeamResolver) gin.HandlerFunc {
+	return keycloakTokenVerifier.TutorScopingMiddleware(resolver)
+}
+
+func GetTutorTeamID(c *gin.Context) (uuid.UUID, bool) {
+	return keycloakTokenVerifier.GetTutorTeamID(c)
 }

--- a/keycloakTokenVerifier/tutorScopingMiddleware.go
+++ b/keycloakTokenVerifier/tutorScopingMiddleware.go
@@ -27,6 +27,9 @@ type TutorTeamResolver interface {
 // editors pass through untouched. pgx.ErrNoRows from the resolver means "not a
 // tutor" (full editor access); any other resolver error fails closed with 500.
 func TutorScopingMiddleware(resolver TutorTeamResolver) gin.HandlerFunc {
+	if resolver == nil {
+		panic("TutorScopingMiddleware: resolver must not be nil")
+	}
 	return func(c *gin.Context) {
 		tokenUser, ok := GetTokenUser(c)
 		if !ok || !tokenUser.IsEditor || tokenUser.IsLecturer {
@@ -41,7 +44,7 @@ func TutorScopingMiddleware(resolver TutorTeamResolver) gin.HandlerFunc {
 		}
 
 		coursePhaseID, err := uuid.Parse(c.Param("coursePhaseID"))
-		if err != nil {
+		if err != nil || coursePhaseID == uuid.Nil {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid course phase id"})
 			return
 		}

--- a/keycloakTokenVerifier/tutorScopingMiddleware.go
+++ b/keycloakTokenVerifier/tutorScopingMiddleware.go
@@ -1,0 +1,73 @@
+package keycloakTokenVerifier
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// TutorTeamIDKey is the gin context key under which the resolved tutor team ID is stored.
+const TutorTeamIDKey = "tutorTeamID"
+
+// TutorTeamResolver is implemented by each service against its own database. It
+// is transport-agnostic (no gin types) so the lookup stays a one-method adapter
+// over the service's sqlc queries.
+type TutorTeamResolver interface {
+	ResolveTutorTeam(ctx context.Context, coursePhaseID uuid.UUID, universityLogin string) (uuid.UUID, error)
+}
+
+// TutorScopingMiddleware resolves the requesting tutor's assigned team and stores
+// it in the gin context for handlers to scope their responses. Only CourseEditor
+// users registered as a tutor are scoped; lecturers, admins and unregistered
+// editors pass through untouched. pgx.ErrNoRows from the resolver means "not a
+// tutor" (full editor access); any other resolver error fails closed with 500.
+func TutorScopingMiddleware(resolver TutorTeamResolver) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tokenUser, ok := GetTokenUser(c)
+		if !ok || !tokenUser.IsEditor || tokenUser.IsLecturer {
+			c.Next()
+			return
+		}
+
+		login := strings.TrimSpace(strings.ToLower(tokenUser.UniversityLogin))
+		if login == "" {
+			c.Next()
+			return
+		}
+
+		coursePhaseID, err := uuid.Parse(c.Param("coursePhaseID"))
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid course phase id"})
+			return
+		}
+
+		teamID, err := resolver.ResolveTutorTeam(c.Request.Context(), coursePhaseID, login)
+		if errors.Is(err, pgx.ErrNoRows) {
+			c.Next()
+			return
+		}
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "access check failed"})
+			return
+		}
+
+		c.Set(TutorTeamIDKey, teamID)
+		c.Next()
+	}
+}
+
+// GetTutorTeamID returns the tutor's scoped team and whether scoping applies to
+// this request. It returns (uuid.Nil, false) when no scoping is active.
+func GetTutorTeamID(c *gin.Context) (uuid.UUID, bool) {
+	if v, exists := c.Get(TutorTeamIDKey); exists {
+		if id, ok := v.(uuid.UUID); ok {
+			return id, true
+		}
+	}
+	return uuid.Nil, false
+}

--- a/keycloakTokenVerifier/tutorScopingMiddleware_test.go
+++ b/keycloakTokenVerifier/tutorScopingMiddleware_test.go
@@ -1,0 +1,112 @@
+package keycloakTokenVerifier
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+type fakeResolver struct {
+	teamID   uuid.UUID
+	err      error
+	called   bool
+	gotLogin string
+}
+
+func (f *fakeResolver) ResolveTutorTeam(_ context.Context, _ uuid.UUID, login string) (uuid.UUID, error) {
+	f.called = true
+	f.gotLogin = login
+	return f.teamID, f.err
+}
+
+func runScoping(t *testing.T, user *TokenUser, phaseParam string, resolver *fakeResolver) (int, uuid.UUID, bool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	var gotTeam uuid.UUID
+	var scoped bool
+	router.GET("/course_phase/:coursePhaseID", func(c *gin.Context) {
+		if user != nil {
+			SetTokenUser(c, *user)
+		}
+	}, TutorScopingMiddleware(resolver), func(c *gin.Context) {
+		gotTeam, scoped = GetTutorTeamID(c)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/course_phase/"+phaseParam, nil)
+	router.ServeHTTP(w, req)
+	return w.Code, gotTeam, scoped
+}
+
+func TestTutorScopingMiddleware(t *testing.T) {
+	phase := uuid.New().String()
+	team := uuid.New()
+
+	t.Run("non-editor bypasses", func(t *testing.T) {
+		r := &fakeResolver{teamID: team}
+		code, _, scoped := runScoping(t, &TokenUser{IsEditor: false, UniversityLogin: "ab12cde"}, phase, r)
+		if code != http.StatusOK || scoped || r.called {
+			t.Fatalf("expected bypass without resolver call, got code=%d scoped=%v called=%v", code, scoped, r.called)
+		}
+	})
+
+	t.Run("lecturer editor bypasses", func(t *testing.T) {
+		r := &fakeResolver{teamID: team}
+		_, _, scoped := runScoping(t, &TokenUser{IsEditor: true, IsLecturer: true, UniversityLogin: "ab12cde"}, phase, r)
+		if scoped || r.called {
+			t.Fatalf("lecturer must not be scoped")
+		}
+	})
+
+	t.Run("empty login bypasses", func(t *testing.T) {
+		r := &fakeResolver{teamID: team}
+		_, _, scoped := runScoping(t, &TokenUser{IsEditor: true, UniversityLogin: "  "}, phase, r)
+		if scoped || r.called {
+			t.Fatalf("empty login must not call resolver")
+		}
+	})
+
+	t.Run("not a tutor (ErrNoRows) grants full access", func(t *testing.T) {
+		r := &fakeResolver{err: pgx.ErrNoRows}
+		code, _, scoped := runScoping(t, &TokenUser{IsEditor: true, UniversityLogin: "ab12cde"}, phase, r)
+		if code != http.StatusOK || scoped || !r.called {
+			t.Fatalf("ErrNoRows must bypass with full access, got code=%d scoped=%v", code, scoped)
+		}
+	})
+
+	t.Run("resolver error fails closed", func(t *testing.T) {
+		r := &fakeResolver{err: errors.New("db down")}
+		code, _, scoped := runScoping(t, &TokenUser{IsEditor: true, UniversityLogin: "ab12cde"}, phase, r)
+		if code != http.StatusInternalServerError || scoped {
+			t.Fatalf("resolver error must fail closed with 500, got code=%d scoped=%v", code, scoped)
+		}
+	})
+
+	t.Run("resolved tutor is scoped with normalized login", func(t *testing.T) {
+		r := &fakeResolver{teamID: team}
+		code, got, scoped := runScoping(t, &TokenUser{IsEditor: true, UniversityLogin: "  AB12CDE  "}, phase, r)
+		if code != http.StatusOK || !scoped || got != team {
+			t.Fatalf("expected scoped team %v, got code=%d team=%v scoped=%v", team, code, got, scoped)
+		}
+		if r.gotLogin != "ab12cde" {
+			t.Fatalf("expected normalized login ab12cde, got %q", r.gotLogin)
+		}
+	})
+
+	t.Run("invalid course phase id returns 400", func(t *testing.T) {
+		r := &fakeResolver{teamID: team}
+		code, _, _ := runScoping(t, &TokenUser{IsEditor: true, UniversityLogin: "ab12cde"}, "not-a-uuid", r)
+		if code != http.StatusBadRequest || r.called {
+			t.Fatalf("invalid phase id must abort 400 before resolver, got code=%d called=%v", code, r.called)
+		}
+	})
+}

--- a/keycloakTokenVerifier/tutorScopingMiddleware_test.go
+++ b/keycloakTokenVerifier/tutorScopingMiddleware_test.go
@@ -109,4 +109,21 @@ func TestTutorScopingMiddleware(t *testing.T) {
 			t.Fatalf("invalid phase id must abort 400 before resolver, got code=%d called=%v", code, r.called)
 		}
 	})
+
+	t.Run("nil course phase id returns 400", func(t *testing.T) {
+		r := &fakeResolver{teamID: team}
+		code, _, _ := runScoping(t, &TokenUser{IsEditor: true, UniversityLogin: "ab12cde"}, uuid.Nil.String(), r)
+		if code != http.StatusBadRequest || r.called {
+			t.Fatalf("nil phase id must abort 400 before resolver, got code=%d called=%v", code, r.called)
+		}
+	})
+}
+
+func TestTutorScopingMiddleware_NilResolverPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("expected panic on nil resolver")
+		}
+	}()
+	TutorScopingMiddleware(nil)
 }

--- a/testutils/mockAuthMiddleware.go
+++ b/testutils/mockAuthMiddleware.go
@@ -79,13 +79,19 @@ func MockTutorEditorMiddleware(universityLogin string) gin.HandlerFunc {
 		userRoles := map[string]bool{keycloakTokenVerifier.CourseEditor: true}
 		c.Set("userRoles", userRoles)
 		c.Set("userEmail", universityLogin+"@tum.de")
+		c.Set("matriculationNumber", "0000000")
 		c.Set("universityLogin", universityLogin)
+		c.Set("firstName", "Tutor")
+		c.Set("lastName", "Editor")
 
 		keycloakTokenVerifier.SetTokenUser(c, keycloakTokenVerifier.TokenUser{
-			Roles:           userRoles,
-			Email:           universityLogin + "@tum.de",
-			UniversityLogin: universityLogin,
-			IsEditor:        true,
+			Roles:               userRoles,
+			Email:               universityLogin + "@tum.de",
+			MatriculationNumber: "0000000",
+			UniversityLogin:     universityLogin,
+			FirstName:           "Tutor",
+			LastName:            "Editor",
+			IsEditor:            true,
 		})
 
 		c.Next()

--- a/testutils/mockAuthMiddleware.go
+++ b/testutils/mockAuthMiddleware.go
@@ -21,9 +21,12 @@ func MockAuthMiddlewareWithEmail(mockRoles []string, email, matriculationNumber,
 		c.Set("lastName", "Doe")
 
 		keycloakTokenVerifier.SetTokenUser(c, keycloakTokenVerifier.TokenUser{
-			Roles:           userRoles,
-			Email:           email,
-			UniversityLogin: universityLogin,
+			Roles:               userRoles,
+			Email:               email,
+			MatriculationNumber: matriculationNumber,
+			UniversityLogin:     universityLogin,
+			FirstName:           "John",
+			LastName:            "Doe",
 		})
 
 		logrus.Info("MockAuthMiddleware: Mocked user mail: ", email)
@@ -57,7 +60,10 @@ func MockAuthMiddlewareWithParticipation(mockRoles []string, courseParticipation
 		keycloakTokenVerifier.SetTokenUser(c, keycloakTokenVerifier.TokenUser{
 			Roles:                 userRoles,
 			Email:                 "test@example.com",
+			MatriculationNumber:   "0000000",
 			UniversityLogin:       "testuser",
+			FirstName:             "Test",
+			LastName:              "User",
 			CourseParticipationID: courseParticipationID,
 		})
 

--- a/testutils/mockAuthMiddleware.go
+++ b/testutils/mockAuthMiddleware.go
@@ -3,24 +3,29 @@ package testutils
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/prompt-edu/prompt-sdk/keycloakTokenVerifier"
 	"github.com/sirupsen/logrus"
 )
 
 func MockAuthMiddlewareWithEmail(mockRoles []string, email, matriculationNumber, universityLogin string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Optionally set mock data, such as roles, for downstream handlers
-		// Create a map for user roles
 		userRoles := make(map[string]bool)
 		for _, role := range mockRoles {
 			userRoles[role] = true
 		}
-		// Store the roles map in the context
 		c.Set("userRoles", userRoles)
 		c.Set("userEmail", email)
 		c.Set("matriculationNumber", matriculationNumber)
 		c.Set("universityLogin", universityLogin)
 		c.Set("firstName", "John")
 		c.Set("lastName", "Doe")
+
+		keycloakTokenVerifier.SetTokenUser(c, keycloakTokenVerifier.TokenUser{
+			Roles:           userRoles,
+			Email:           email,
+			UniversityLogin: universityLogin,
+		})
+
 		logrus.Info("MockAuthMiddleware: Mocked user mail: ", email)
 		c.Next()
 	}
@@ -49,7 +54,34 @@ func MockAuthMiddlewareWithParticipation(mockRoles []string, courseParticipation
 		c.Set("lastName", "User")
 		c.Set("courseParticipationID", courseParticipationID)
 
+		keycloakTokenVerifier.SetTokenUser(c, keycloakTokenVerifier.TokenUser{
+			Roles:                 userRoles,
+			Email:                 "test@example.com",
+			UniversityLogin:       "testuser",
+			CourseParticipationID: courseParticipationID,
+		})
+
 		logrus.Info("MockAuthMiddleware: set courseParticipationID ", courseParticipationID)
+		c.Next()
+	}
+}
+
+// MockTutorEditorMiddleware creates a mock for a CourseEditor who is registered as a tutor.
+// The universityLogin is used by tutorScopingMiddleware to look up the tutor's team.
+func MockTutorEditorMiddleware(universityLogin string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userRoles := map[string]bool{keycloakTokenVerifier.CourseEditor: true}
+		c.Set("userRoles", userRoles)
+		c.Set("userEmail", universityLogin+"@tum.de")
+		c.Set("universityLogin", universityLogin)
+
+		keycloakTokenVerifier.SetTokenUser(c, keycloakTokenVerifier.TokenUser{
+			Roles:           userRoles,
+			Email:           universityLogin + "@tum.de",
+			UniversityLogin: universityLogin,
+			IsEditor:        true,
+		})
+
 		c.Next()
 	}
 }


### PR DESCRIPTION
## What

Implements the reusable tutor scoping middleware proposed in #89 so phase services no longer each maintain a local copy.

- `TutorTeamResolver` — transport-agnostic one-method interface each service implements over its own sqlc queries (no gin types).
- `TutorScopingMiddleware(resolver)` — scopes `CourseEditor` (tutor) requests to their assigned team, injected into the gin context under `TutorTeamIDKey`.
- `GetTutorTeamID(c)` — reads the injected team ID in handlers.
- Re-exported at the root `promptSDK` package alongside the other auth helpers.
- `testutils.MockTutorEditorMiddleware(universityLogin)` for downstream tests.

## Behaviour contract

| Condition | Result |
|---|---|
| Not `IsEditor`, or `IsLecturer` | `c.Next()` — bypass |
| `UniversityLogin` empty | `c.Next()` — bypass |
| Resolver returns `pgx.ErrNoRows` | `c.Next()` — not a tutor, full editor access |
| Resolver returns another error | `500` — fail closed |
| Resolver succeeds | inject `teamID`, `c.Next()` |

University login is normalized (`TrimSpace` + `ToLower`) before the resolver call. An invalid `coursePhaseID` path param aborts with `400` before the resolver runs.

## Why

`team_allocation` (PR prompt-edu/prompt#1853) carries a local copy of this middleware; extracting it lets that and future phases (`self_team_allocation`) adopt scoping with a one-method resolver.

## Testing

`go test ./...` — table tests in `tutorScopingMiddleware_test.go` cover every row of the contract above, including fail-closed and login normalization.

Closes #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tutor team scoping for authenticated users, letting the app automatically determine and store the tutor’s team when applicable.
  - Exposed a helper to read the resolved tutor team from request context for downstream features.

- **Bug Fixes**
  - Requests now handle missing team assignments gracefully and reject invalid course phase input with a clear client error.

- **Tests**
  - Added coverage for scoping behavior across access, validation, and error-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->