### PR TITLE
Add course phase deletion handler and capability

### DIFF
--- a/promptTypes/coursePhaseDeletion.go
+++ b/promptTypes/coursePhaseDeletion.go
@@ -1,0 +1,72 @@
+package promptTypes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/prompt-edu/prompt-sdk/keycloakTokenVerifier"
+	"github.com/sirupsen/logrus"
+)
+
+// CoursePhaseDeletionRequest represents the payload used to trigger the deletion of a course phase.
+// It is sent to a module the moment a course phase is permanently deleted, giving the module a
+// chance to remove all data it stores for that phase.
+type CoursePhaseDeletionRequest struct {
+	// CoursePhaseID is the unique identifier of the course phase being deleted.
+	// The module should delete everything it stores that is scoped to this phase.
+	CoursePhaseID uuid.UUID `json:"coursePhaseID"`
+}
+
+// CoursePhaseDeletionHandler defines the interface that modules must implement to support
+// course phase deletion. Any module that stores course phase-specific data should implement
+// this interface to ensure their data is properly removed when a course phase is deleted.
+type CoursePhaseDeletionHandler interface {
+	// HandleCoursePhaseDeletion processes the deletion of module-specific data scoped to the
+	// course phase in the request. Implementations should:
+	//   - Delete all data, settings, and state stored for the given course phase
+	//   - Be idempotent: deleting a phase for which no data exists is a success, and
+	//     re-running the deletion must not fail
+	//
+	// Returns an error if the deletion operation fails for any reason.
+	HandleCoursePhaseDeletion(c *gin.Context, req CoursePhaseDeletionRequest) error
+}
+
+// RegisterCoursePhaseDeletionEndpoint registers the standardized POST /delete endpoint for course
+// phase deletion. Because permanently removing a phase's data is a destructive, course-spanning
+// operation, the SDK protects the endpoint with a PromptAdmin-only middleware itself, rather than
+// accepting an authorization middleware from the caller. This mirrors the privacy data deletion
+// endpoint.
+//
+// The endpoint standardizes the response codes:
+//   - 200 OK: The deletion of data for the course phase was successful. This is also returned if
+//     there was no data stored for that phase.
+//   - 400 Bad Request: The request did not match the expected format.
+//   - 500 Internal Server Error: Something went wrong and the deletion may not have been successful.
+//
+// Because the handler is expected to be idempotent, the endpoint returns 200 OK even when the
+// module stored no data for the phase.
+//
+// Internal errors are not exposed to the caller, but are logged.
+//
+// Example endpoint path: POST /self-team-allocation/api/course_phase/:coursePhaseID/delete
+func RegisterCoursePhaseDeletionEndpoint(router *gin.RouterGroup, handler CoursePhaseDeletionHandler) {
+
+	adminOnlyMiddleware := keycloakTokenVerifier.AuthenticationMiddleware(keycloakTokenVerifier.PromptAdmin)
+	router.POST("/delete", adminOnlyMiddleware, func(c *gin.Context) {
+		var req CoursePhaseDeletionRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			logrus.Error("caller passed invalid request body")
+			c.JSON(http.StatusBadRequest, gin.H{"error": "request body for deletion does not match CoursePhaseDeletionRequest as defined in the SDK"})
+			return
+		}
+
+		if err := handler.HandleCoursePhaseDeletion(c, req); err != nil {
+			logrus.Error("course phase deletion was not successful, error: ", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to process course phase deletion"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"success": "Course phase deletion request executed"})
+	})
+}

--- a/promptTypes/coursePhaseDeletion.go
+++ b/promptTypes/coursePhaseDeletion.go
@@ -9,39 +9,35 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// CoursePhaseDeletionRequest represents the payload used to trigger the deletion of a course phase.
-// It is sent to a module the moment a course phase is permanently deleted, giving the module a
-// chance to remove all data it stores for that phase.
-type CoursePhaseDeletionRequest struct {
-	// CoursePhaseID is the unique identifier of the course phase being deleted.
-	// The module should delete everything it stores that is scoped to this phase.
-	CoursePhaseID uuid.UUID `json:"coursePhaseID"`
-}
-
 // CoursePhaseDeletionHandler defines the interface that modules must implement to support
 // course phase deletion. Any module that stores course phase-specific data should implement
 // this interface to ensure their data is properly removed when a course phase is deleted.
 type CoursePhaseDeletionHandler interface {
-	// HandleCoursePhaseDeletion processes the deletion of module-specific data scoped to the
-	// course phase in the request. Implementations should:
+	// HandleCoursePhaseDeletion deletes all module-specific data scoped to the given course
+	// phase. It is called the moment a course phase is permanently deleted, giving the module
+	// a chance to remove everything it stores for that phase. Implementations should:
 	//   - Delete all data, settings, and state stored for the given course phase
 	//   - Be idempotent: deleting a phase for which no data exists is a success, and
 	//     re-running the deletion must not fail
 	//
 	// Returns an error if the deletion operation fails for any reason.
-	HandleCoursePhaseDeletion(c *gin.Context, req CoursePhaseDeletionRequest) error
+	HandleCoursePhaseDeletion(c *gin.Context, coursePhaseID uuid.UUID) error
 }
 
 // RegisterCoursePhaseDeletionEndpoint registers the standardized POST /delete endpoint for course
-// phase deletion. Because permanently removing a phase's data is a destructive, course-spanning
-// operation, the SDK protects the endpoint with a PromptAdmin-only middleware itself, rather than
-// accepting an authorization middleware from the caller. This mirrors the privacy data deletion
-// endpoint.
+// phase deletion. Because permanently removing a phase's data is a destructive operation, the SDK
+// protects the endpoint itself rather than accepting an authorization middleware from the caller:
+// it allows PromptAdmin and CourseLecturer, mirroring the roles the core server requires to delete
+// a course phase.
+//
+// The endpoint MUST be registered on a router group whose path contains ":coursePhaseID"
+// (e.g. ".../api/course_phase/:coursePhaseID"). The course phase ID is read from that path
+// parameter, and it is also required to resolve the CourseLecturer role.
 //
 // The endpoint standardizes the response codes:
 //   - 200 OK: The deletion of data for the course phase was successful. This is also returned if
 //     there was no data stored for that phase.
-//   - 400 Bad Request: The request did not match the expected format.
+//   - 400 Bad Request: The course phase ID in the path was missing or malformed.
 //   - 500 Internal Server Error: Something went wrong and the deletion may not have been successful.
 //
 // Because the handler is expected to be idempotent, the endpoint returns 200 OK even when the
@@ -52,16 +48,16 @@ type CoursePhaseDeletionHandler interface {
 // Example endpoint path: POST /self-team-allocation/api/course_phase/:coursePhaseID/delete
 func RegisterCoursePhaseDeletionEndpoint(router *gin.RouterGroup, handler CoursePhaseDeletionHandler) {
 
-	adminOnlyMiddleware := keycloakTokenVerifier.AuthenticationMiddleware(keycloakTokenVerifier.PromptAdmin)
-	router.POST("/delete", adminOnlyMiddleware, func(c *gin.Context) {
-		var req CoursePhaseDeletionRequest
-		if err := c.ShouldBindJSON(&req); err != nil {
-			logrus.Error("caller passed invalid request body")
-			c.JSON(http.StatusBadRequest, gin.H{"error": "request body for deletion does not match CoursePhaseDeletionRequest as defined in the SDK"})
+	authMiddleware := keycloakTokenVerifier.AuthenticationMiddleware(keycloakTokenVerifier.PromptAdmin, keycloakTokenVerifier.CourseLecturer)
+	router.POST("/delete", authMiddleware, func(c *gin.Context) {
+		coursePhaseID, err := uuid.Parse(c.Param("coursePhaseID"))
+		if err != nil {
+			logrus.Error("caller passed invalid or missing coursePhaseID path parameter")
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid or missing coursePhaseID"})
 			return
 		}
 
-		if err := handler.HandleCoursePhaseDeletion(c, req); err != nil {
+		if err := handler.HandleCoursePhaseDeletion(c, coursePhaseID); err != nil {
 			logrus.Error("course phase deletion was not successful, error: ", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to process course phase deletion"})
 			return

--- a/promptTypes/serviceInfo.go
+++ b/promptTypes/serviceInfo.go
@@ -15,6 +15,11 @@ const (
 	// Expected endpoint: POST .../course_phase/:coursePhaseID/copy
 	CapabilityPhaseCopy = "phase.copy"
 
+	// CapabilityPhaseDeletion indicates support for deleting all data a module
+	// stores for a course phase when that phase is permanently deleted.
+	// Expected endpoint: POST .../course_phase/:coursePhaseID/delete
+	CapabilityPhaseDeletion = "phase.deletion"
+
 	// CapabilityPhaseConfig indicates support for reporting the configuration
 	// status of a course phase.
 	// Expected endpoint: GET .../course_phase/:coursePhaseID/config


### PR DESCRIPTION
This PR introduces the course phase deletion handler for the sdk, which makes it easy for CPMs to implement the corresponding course phase deletion route.

This route will get called when a course phase is unrevokably deleted from the course configurator.

Find more details here https://github.com/prompt-edu/prompt/issues/984

Since a course lecturer can edit the course phase graph, this route is also available to a course lecturer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added a standardized POST endpoint for permanently deleting all data associated with a course phase.
- Added capability reporting for course-phase deletion support.
- Requests now validate the course-phase identifier and enforce appropriate access controls.
- Responses clearly indicate successful, invalid, or failed deletion requests.
- Deletion is idempotent, so requests succeed even when no course-phase data exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->