### PR TITLE
`Authentication`: Add student ownership validation helper

### DIFF
--- a/keycloakTokenVerifier/ownership.go
+++ b/keycloakTokenVerifier/ownership.go
@@ -1,0 +1,63 @@
+package keycloakTokenVerifier
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+var ErrCourseParticipationIDNotFound = errors.New("course participation ID not found")
+var ErrInvalidCourseParticipationIDFormat = errors.New("invalid course participation ID format")
+var ErrInvalidCourseParticipationID = errors.New("invalid course participation ID")
+
+func GetUserCourseParticipationIDErrorStatus(err error) int {
+	switch err {
+	case ErrCourseParticipationIDNotFound:
+		return http.StatusUnauthorized
+	case ErrInvalidCourseParticipationIDFormat, ErrInvalidCourseParticipationID:
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func GetUserCourseParticipationID(c *gin.Context) (uuid.UUID, error) {
+	userCourseParticipationID, exists := c.Get("courseParticipationID")
+	if !exists {
+		return uuid.UUID{}, ErrCourseParticipationIDNotFound
+	}
+
+	userCourseParticipationUUID, ok := userCourseParticipationID.(uuid.UUID)
+	if !ok {
+		userCourseParticipationStr, ok := userCourseParticipationID.(string)
+		if !ok {
+			return uuid.UUID{}, ErrInvalidCourseParticipationIDFormat
+		}
+		var err error
+		userCourseParticipationUUID, err = uuid.Parse(userCourseParticipationStr)
+		if err != nil {
+			return uuid.UUID{}, ErrInvalidCourseParticipationID
+		}
+	}
+
+	return userCourseParticipationUUID, nil
+}
+
+// ValidateStudentOwnership verifies that the authenticated student only acts on their own
+// course participation. ownedEntityName names the entity in the forbidden error message
+// (e.g. "evaluation completions", "interview assignments").
+func ValidateStudentOwnership(c *gin.Context, authorCourseParticipationID uuid.UUID, ownedEntityName string) (int, error) {
+	userCourseParticipationUUID, err := GetUserCourseParticipationID(c)
+	if err != nil {
+		return GetUserCourseParticipationIDErrorStatus(err), err
+	}
+
+	if authorCourseParticipationID != userCourseParticipationUUID {
+		return http.StatusForbidden, fmt.Errorf("you can only manage your own %s", ownedEntityName)
+	}
+
+	return http.StatusOK, nil
+}

--- a/keycloakTokenVerifier/ownership_test.go
+++ b/keycloakTokenVerifier/ownership_test.go
@@ -1,0 +1,47 @@
+package keycloakTokenVerifier
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUserCourseParticipationID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	testUUID := uuid.MustParse("12345678-1234-1234-1234-123456789012")
+
+	c, _ := gin.CreateTestContext(nil)
+	c.Set("courseParticipationID", testUUID)
+
+	result, err := GetUserCourseParticipationID(c)
+	require.NoError(t, err)
+	require.Equal(t, testUUID, result)
+}
+
+func TestValidateStudentOwnership(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	userUUID := uuid.MustParse("12345678-1234-1234-1234-123456789012")
+
+	c, _ := gin.CreateTestContext(nil)
+	c.Set("courseParticipationID", userUUID)
+
+	status, err := ValidateStudentOwnership(c, userUUID, "evaluation completions")
+	require.NoError(t, err)
+	require.Equal(t, 200, status)
+}
+
+func TestValidateStudentOwnershipForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	userUUID := uuid.MustParse("12345678-1234-1234-1234-123456789012")
+	otherUUID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+
+	c, _ := gin.CreateTestContext(nil)
+	c.Set("courseParticipationID", userUUID)
+
+	status, err := ValidateStudentOwnership(c, otherUUID, "interview assignments")
+	require.Error(t, err)
+	require.Equal(t, 403, status)
+	require.EqualError(t, err, "you can only manage your own interview assignments")
+}


### PR DESCRIPTION
## Summary

Adds a student ownership validation helper to the SDK, as requested in #104. Two phase services (`assessment`, `interview`) carried a near file-for-file copy of `utils/ownership.go`, identical except for one error message string (`"evaluation completions"` vs `"interview assignments"`).

Moves the helper into `keycloakTokenVerifier/` next to the existing token/participation accessors (`GetTokenUser`, and the `courseParticipationID` context key set by `getIsStudent.go`), parameterizing the mismatched message via an `ownedEntityName string` argument:

```go
func ValidateStudentOwnership(c *gin.Context, authorCourseParticipationID uuid.UUID, ownedEntityName string) (int, error)
```

Also exports `GetUserCourseParticipationID`, `GetUserCourseParticipationIDErrorStatus`, and the sentinel errors. Ported the existing test plus a forbidden-case test.

## Notes

- Consumer migration (dropping both local `utils/ownership.go` copies) is tracked in `prompt-edu/prompt`.

Closes #104
