### PR TITLE
`API`: Add generic Register{Config,Copy,Privacy}Module helpers for phase sub-modules

### DIFF
--- a/promptTypes/coursePhaseDeletion.go
+++ b/promptTypes/coursePhaseDeletion.go
@@ -1,0 +1,72 @@
+package promptTypes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/prompt-edu/prompt-sdk/keycloakTokenVerifier"
+	"github.com/sirupsen/logrus"
+)
+
+// CoursePhaseDeletionRequest represents the payload used to trigger the deletion of a course phase.
+// It is sent to a module the moment a course phase is permanently deleted, giving the module a
+// chance to remove all data it stores for that phase.
+type CoursePhaseDeletionRequest struct {
+	// CoursePhaseID is the unique identifier of the course phase being deleted.
+	// The module should delete everything it stores that is scoped to this phase.
+	CoursePhaseID uuid.UUID `json:"coursePhaseID"`
+}
+
+// CoursePhaseDeletionHandler defines the interface that modules must implement to support
+// course phase deletion. Any module that stores course phase-specific data should implement
+// this interface to ensure their data is properly removed when a course phase is deleted.
+type CoursePhaseDeletionHandler interface {
+	// HandleCoursePhaseDeletion processes the deletion of module-specific data scoped to the
+	// course phase in the request. Implementations should:
+	//   - Delete all data, settings, and state stored for the given course phase
+	//   - Be idempotent: deleting a phase for which no data exists is a success, and
+	//     re-running the deletion must not fail
+	//
+	// Returns an error if the deletion operation fails for any reason.
+	HandleCoursePhaseDeletion(c *gin.Context, req CoursePhaseDeletionRequest) error
+}
+
+// RegisterCoursePhaseDeletionEndpoint registers the standardized POST /delete endpoint for course
+// phase deletion. Because permanently removing a phase's data is a destructive, course-spanning
+// operation, the SDK protects the endpoint with a PromptAdmin-only middleware itself, rather than
+// accepting an authorization middleware from the caller. This mirrors the privacy data deletion
+// endpoint.
+//
+// The endpoint standardizes the response codes:
+//   - 200 OK: The deletion of data for the course phase was successful. This is also returned if
+//     there was no data stored for that phase.
+//   - 400 Bad Request: The request did not match the expected format.
+//   - 500 Internal Server Error: Something went wrong and the deletion may not have been successful.
+//
+// Because the handler is expected to be idempotent, the endpoint returns 200 OK even when the
+// module stored no data for the phase.
+//
+// Internal errors are not exposed to the caller, but are logged.
+//
+// Example endpoint path: POST /self-team-allocation/api/course_phase/:coursePhaseID/delete
+func RegisterCoursePhaseDeletionEndpoint(router *gin.RouterGroup, handler CoursePhaseDeletionHandler) {
+
+	adminOnlyMiddleware := keycloakTokenVerifier.AuthenticationMiddleware(keycloakTokenVerifier.PromptAdmin)
+	router.POST("/delete", adminOnlyMiddleware, func(c *gin.Context) {
+		var req CoursePhaseDeletionRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			logrus.Error("caller passed invalid request body")
+			c.JSON(http.StatusBadRequest, gin.H{"error": "request body for deletion does not match CoursePhaseDeletionRequest as defined in the SDK"})
+			return
+		}
+
+		if err := handler.HandleCoursePhaseDeletion(c, req); err != nil {
+			logrus.Error("course phase deletion was not successful, error: ", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to process course phase deletion"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"success": "Course phase deletion request executed"})
+	})
+}

--- a/promptTypes/coursePhaseDeletion.go
+++ b/promptTypes/coursePhaseDeletion.go
@@ -9,39 +9,35 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// CoursePhaseDeletionRequest represents the payload used to trigger the deletion of a course phase.
-// It is sent to a module the moment a course phase is permanently deleted, giving the module a
-// chance to remove all data it stores for that phase.
-type CoursePhaseDeletionRequest struct {
-	// CoursePhaseID is the unique identifier of the course phase being deleted.
-	// The module should delete everything it stores that is scoped to this phase.
-	CoursePhaseID uuid.UUID `json:"coursePhaseID"`
-}
-
 // CoursePhaseDeletionHandler defines the interface that modules must implement to support
 // course phase deletion. Any module that stores course phase-specific data should implement
 // this interface to ensure their data is properly removed when a course phase is deleted.
 type CoursePhaseDeletionHandler interface {
-	// HandleCoursePhaseDeletion processes the deletion of module-specific data scoped to the
-	// course phase in the request. Implementations should:
+	// HandleCoursePhaseDeletion deletes all module-specific data scoped to the given course
+	// phase. It is called the moment a course phase is permanently deleted, giving the module
+	// a chance to remove everything it stores for that phase. Implementations should:
 	//   - Delete all data, settings, and state stored for the given course phase
 	//   - Be idempotent: deleting a phase for which no data exists is a success, and
 	//     re-running the deletion must not fail
 	//
 	// Returns an error if the deletion operation fails for any reason.
-	HandleCoursePhaseDeletion(c *gin.Context, req CoursePhaseDeletionRequest) error
+	HandleCoursePhaseDeletion(c *gin.Context, coursePhaseID uuid.UUID) error
 }
 
 // RegisterCoursePhaseDeletionEndpoint registers the standardized POST /delete endpoint for course
-// phase deletion. Because permanently removing a phase's data is a destructive, course-spanning
-// operation, the SDK protects the endpoint with a PromptAdmin-only middleware itself, rather than
-// accepting an authorization middleware from the caller. This mirrors the privacy data deletion
-// endpoint.
+// phase deletion. Because permanently removing a phase's data is a destructive operation, the SDK
+// protects the endpoint itself rather than accepting an authorization middleware from the caller:
+// it allows PromptAdmin and CourseLecturer, mirroring the roles the core server requires to delete
+// a course phase.
+//
+// The endpoint MUST be registered on a router group whose path contains ":coursePhaseID"
+// (e.g. ".../api/course_phase/:coursePhaseID"). The course phase ID is read from that path
+// parameter, and it is also required to resolve the CourseLecturer role.
 //
 // The endpoint standardizes the response codes:
 //   - 200 OK: The deletion of data for the course phase was successful. This is also returned if
 //     there was no data stored for that phase.
-//   - 400 Bad Request: The request did not match the expected format.
+//   - 400 Bad Request: The course phase ID in the path was missing or malformed.
 //   - 500 Internal Server Error: Something went wrong and the deletion may not have been successful.
 //
 // Because the handler is expected to be idempotent, the endpoint returns 200 OK even when the
@@ -52,16 +48,16 @@ type CoursePhaseDeletionHandler interface {
 // Example endpoint path: POST /self-team-allocation/api/course_phase/:coursePhaseID/delete
 func RegisterCoursePhaseDeletionEndpoint(router *gin.RouterGroup, handler CoursePhaseDeletionHandler) {
 
-	adminOnlyMiddleware := keycloakTokenVerifier.AuthenticationMiddleware(keycloakTokenVerifier.PromptAdmin)
-	router.POST("/delete", adminOnlyMiddleware, func(c *gin.Context) {
-		var req CoursePhaseDeletionRequest
-		if err := c.ShouldBindJSON(&req); err != nil {
-			logrus.Error("caller passed invalid request body")
-			c.JSON(http.StatusBadRequest, gin.H{"error": "request body for deletion does not match CoursePhaseDeletionRequest as defined in the SDK"})
+	authMiddleware := keycloakTokenVerifier.AuthenticationMiddleware(keycloakTokenVerifier.PromptAdmin, keycloakTokenVerifier.CourseLecturer)
+	router.POST("/delete", authMiddleware, func(c *gin.Context) {
+		coursePhaseID, err := uuid.Parse(c.Param("coursePhaseID"))
+		if err != nil {
+			logrus.Error("caller passed invalid or missing coursePhaseID path parameter")
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid or missing coursePhaseID"})
 			return
 		}
 
-		if err := handler.HandleCoursePhaseDeletion(c, req); err != nil {
+		if err := handler.HandleCoursePhaseDeletion(c, coursePhaseID); err != nil {
 			logrus.Error("course phase deletion was not successful, error: ", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to process course phase deletion"})
 			return

--- a/promptTypes/moduleRegistrars.go
+++ b/promptTypes/moduleRegistrars.go
@@ -1,0 +1,37 @@
+package promptTypes
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/prompt-edu/prompt-sdk/keycloakTokenVerifier"
+)
+
+// RegisterConfigModule wires a phase config module onto the given router group: it builds the
+// role-based auth middleware from the allowed roles and registers the standardized /config
+// endpoint behind it. Replaces the per-service setupConfigRouter glue.
+func RegisterConfigModule(group *gin.RouterGroup, handler PhaseConfigHandler, roles ...string) {
+	RegisterConfigEndpoint(group, keycloakTokenVerifier.AuthenticationMiddleware(roles...), handler)
+}
+
+// RegisterCopyModule wires a phase copy module onto the given router group: it builds the
+// role-based auth middleware from the allowed roles and registers the standardized /copy
+// endpoint behind it. Replaces the per-service setupCopyRouter glue.
+func RegisterCopyModule(group *gin.RouterGroup, handler PhaseCopyHandler, roles ...string) {
+	RegisterCopyEndpoint(group, keycloakTokenVerifier.AuthenticationMiddleware(roles...), handler)
+}
+
+// RegisterPrivacyModule wires a phase privacy module onto the given router group by registering the
+// standardized privacy data-export endpoint and, when a deletion handler is supplied, the
+// data-deletion endpoint. Both endpoints manage their own authentication (export accepts any valid
+// token, deletion is admin-only), so no roles are taken here. Pass a nil deletion handler to
+// register the export endpoint only.
+func RegisterPrivacyModule(
+	group *gin.RouterGroup,
+	export PrivacyDataExportHandler,
+	deletion PrivacyDataDeletionHandler,
+	allowedUploadHosts []string,
+) {
+	RegisterPrivacyDataExportEndpoint(group, export, allowedUploadHosts)
+	if deletion != nil {
+		RegisterPrivacyDataDeletionEndpoint(group, deletion)
+	}
+}

--- a/promptTypes/moduleRegistrars.go
+++ b/promptTypes/moduleRegistrars.go
@@ -19,6 +19,18 @@ func RegisterCopyModule(group *gin.RouterGroup, handler PhaseCopyHandler, roles 
 	RegisterCopyEndpoint(group, keycloakTokenVerifier.AuthenticationMiddleware(roles...), handler)
 }
 
+// RegisterPhaseDeletionModule wires a phase deletion module onto the given router group: it
+// registers the standardized /delete endpoint. The endpoint protects itself (PromptAdmin and
+// CourseLecturer, mirroring the core server), so no roles are taken here. It is named after the
+// phase.deletion capability to keep it apart from the privacy deletion handled by
+// RegisterPrivacyModule.
+//
+// The group's path must contain ":coursePhaseID" (e.g. ".../api/course_phase/:coursePhaseID"),
+// as required by RegisterCoursePhaseDeletionEndpoint.
+func RegisterPhaseDeletionModule(group *gin.RouterGroup, handler CoursePhaseDeletionHandler) {
+	RegisterCoursePhaseDeletionEndpoint(group, handler)
+}
+
 // RegisterPrivacyModule wires a phase privacy module onto the given router group by registering the
 // standardized privacy data-export endpoint and, when a deletion handler is supplied, the
 // data-deletion endpoint. Both endpoints manage their own authentication (export accepts any valid

--- a/promptTypes/moduleRegistrars_test.go
+++ b/promptTypes/moduleRegistrars_test.go
@@ -1,0 +1,66 @@
+package promptTypes
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prompt-edu/prompt-sdk/keycloakTokenVerifier"
+	"github.com/prompt-edu/prompt-sdk/utils"
+	"github.com/stretchr/testify/require"
+)
+
+type stubConfigHandler struct{}
+
+func (stubConfigHandler) HandlePhaseConfig(*gin.Context) (map[string]bool, error) {
+	return map[string]bool{}, nil
+}
+
+type stubCopyHandler struct{}
+
+func (stubCopyHandler) HandlePhaseCopy(*gin.Context, PhaseCopyRequest) error { return nil }
+
+func registeredRoutes(t *testing.T, register func(*gin.RouterGroup)) map[string]bool {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	register(r.Group("/course_phase/:coursePhaseID"))
+
+	routes := map[string]bool{}
+	for _, route := range r.Routes() {
+		routes[route.Method+" "+route.Path] = true
+	}
+	return routes
+}
+
+func TestRegisterConfigAndCopyModule(t *testing.T) {
+	routes := registeredRoutes(t, func(g *gin.RouterGroup) {
+		RegisterConfigModule(g, stubConfigHandler{}, keycloakTokenVerifier.PromptAdmin)
+		RegisterCopyModule(g, stubCopyHandler{}, keycloakTokenVerifier.PromptAdmin)
+	})
+
+	require.True(t, routes["GET /course_phase/:coursePhaseID/config"])
+	require.True(t, routes["POST /course_phase/:coursePhaseID/copy"])
+}
+
+func TestRegisterPrivacyModuleWithDeletion(t *testing.T) {
+	export := func(*gin.Context, *utils.Export, keycloakTokenVerifier.SubjectIdentifiers) error { return nil }
+	deletion := func(*gin.Context, keycloakTokenVerifier.SubjectIdentifiers) error { return nil }
+
+	routes := registeredRoutes(t, func(g *gin.RouterGroup) {
+		RegisterPrivacyModule(g, export, deletion, nil)
+	})
+
+	require.True(t, routes["POST /course_phase/:coursePhaseID"+PrivacyRouteDataExport])
+	require.True(t, routes["POST /course_phase/:coursePhaseID"+PrivacyRouteDataDeletion])
+}
+
+func TestRegisterPrivacyModuleExportOnly(t *testing.T) {
+	export := func(*gin.Context, *utils.Export, keycloakTokenVerifier.SubjectIdentifiers) error { return nil }
+
+	routes := registeredRoutes(t, func(g *gin.RouterGroup) {
+		RegisterPrivacyModule(g, export, nil, nil)
+	})
+
+	require.True(t, routes["POST /course_phase/:coursePhaseID"+PrivacyRouteDataExport])
+	require.False(t, routes["POST /course_phase/:coursePhaseID"+PrivacyRouteDataDeletion])
+}

--- a/promptTypes/moduleRegistrars_test.go
+++ b/promptTypes/moduleRegistrars_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/prompt-edu/prompt-sdk/keycloakTokenVerifier"
 	"github.com/prompt-edu/prompt-sdk/utils"
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,10 @@ func (stubConfigHandler) HandlePhaseConfig(*gin.Context) (map[string]bool, error
 type stubCopyHandler struct{}
 
 func (stubCopyHandler) HandlePhaseCopy(*gin.Context, PhaseCopyRequest) error { return nil }
+
+type stubDeletionHandler struct{}
+
+func (stubDeletionHandler) HandleCoursePhaseDeletion(*gin.Context, uuid.UUID) error { return nil }
 
 func registeredRoutes(t *testing.T, register func(*gin.RouterGroup)) map[string]bool {
 	t.Helper()
@@ -40,6 +45,14 @@ func TestRegisterConfigAndCopyModule(t *testing.T) {
 
 	require.True(t, routes["GET /course_phase/:coursePhaseID/config"])
 	require.True(t, routes["POST /course_phase/:coursePhaseID/copy"])
+}
+
+func TestRegisterPhaseDeletionModule(t *testing.T) {
+	routes := registeredRoutes(t, func(g *gin.RouterGroup) {
+		RegisterPhaseDeletionModule(g, stubDeletionHandler{})
+	})
+
+	require.True(t, routes["POST /course_phase/:coursePhaseID/delete"])
 }
 
 func TestRegisterPrivacyModuleWithDeletion(t *testing.T) {

--- a/promptTypes/serviceInfo.go
+++ b/promptTypes/serviceInfo.go
@@ -15,6 +15,11 @@ const (
 	// Expected endpoint: POST .../course_phase/:coursePhaseID/copy
 	CapabilityPhaseCopy = "phase.copy"
 
+	// CapabilityPhaseDeletion indicates support for deleting all data a module
+	// stores for a course phase when that phase is permanently deleted.
+	// Expected endpoint: POST .../course_phase/:coursePhaseID/delete
+	CapabilityPhaseDeletion = "phase.deletion"
+
 	// CapabilityPhaseConfig indicates support for reporting the configuration
 	// status of a course phase.
 	// Expected endpoint: GET .../course_phase/:coursePhaseID/config


### PR DESCRIPTION
## Summary

Adds generic module registrars for the phase sub-modules, as requested in #103. The `config/`, `copy/`, and `privacy/` sub-modules of each phase service share an identical Service + Singleton + Init + `setupRouter` scaffold. Only the handler bodies genuinely differ; the glue wiring them to the SDK endpoint registrars is copy-pasted (`setupConfigRouter`, `setupCopyRouter`, `InitPrivacyModule`).

Adds thin module registrars so the per-service glue collapses to a single call:

```go
func RegisterConfigModule(group *gin.RouterGroup, handler PhaseConfigHandler, roles ...string)
func RegisterCopyModule(group *gin.RouterGroup, handler PhaseCopyHandler, roles ...string)
func RegisterPhaseDeletionModule(group *gin.RouterGroup, handler CoursePhaseDeletionHandler)
func RegisterPrivacyModule(group *gin.RouterGroup, export PrivacyDataExportHandler, deletion PrivacyDataDeletionHandler, allowedUploadHosts []string)
```

- `RegisterConfigModule` / `RegisterCopyModule` build the role-based auth middleware (`keycloakTokenVerifier.AuthenticationMiddleware(roles...)`) and register the endpoint behind it, matching today's `setupXxxRouter`.
- `RegisterPhaseDeletionModule` registers the `/delete` endpoint from #101. The endpoint protects itself (PromptAdmin and CourseLecturer), so it takes no roles. It is named after the `phase.deletion` capability to keep it apart from the privacy deletion in `RegisterPrivacyModule`.
- `RegisterPrivacyModule` registers the export endpoint and, when a non-nil deletion handler is supplied, the deletion endpoint (certificate registers both; interview registers export only).

## Depends on #101

This PR depends on #101 (`Add course phase deletion handler and capability`). That branch is merged into this one, so the diff here also contains `promptTypes/coursePhaseDeletion.go` and the `phase.deletion` capability. `RegisterPhaseDeletionModule` wraps the endpoint registrar #101 introduces and does not compile without it. Merge #101 first, then this PR.

### Deviation from the proposal

The issue sketched `RegisterPrivacyModule(..., roles ...string)`. The privacy endpoints already manage their own auth (export accepts any valid token, deletion is admin-only), so roles don't apply. The signature instead takes `allowedUploadHosts` (needed by the export endpoint) and an optional `deletion` handler.

## Notes

- Consumer migration is tracked in `prompt-edu/prompt`.

Closes #103
