### PR TITLE
`Infrastructure`: Fix deprecated Sentry logrus event hook

### DIFF
--- a/utils/initSentry.go
+++ b/utils/initSentry.go
@@ -48,16 +48,13 @@ func InitSentry(sentryDsn string) error {
 		client,
 	)
 
-	eventHook := sentrylogrus.NewEventHookFromClient(
-		[]log.Level{log.ErrorLevel, log.FatalLevel, log.PanicLevel},
-		client,
-	)
+	eventHook := newSentryEventHook([]log.Level{log.ErrorLevel, log.FatalLevel, log.PanicLevel})
 
 	log.AddHook(logHook)
 	log.AddHook(eventHook)
 
 	log.RegisterExitHandler(func() {
-		eventHook.Flush(5 * time.Second)
+		sentry.Flush(5 * time.Second)
 		logHook.Flush(5 * time.Second)
 	})
 

--- a/utils/sentryEventHook.go
+++ b/utils/sentryEventHook.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"github.com/getsentry/sentry-go"
+	log "github.com/sirupsen/logrus"
+)
+
+// logrusToSentryLevel maps the error-class logrus levels to Sentry levels.
+var logrusToSentryLevel = map[log.Level]sentry.Level{
+	log.ErrorLevel: sentry.LevelError,
+	log.FatalLevel: sentry.LevelFatal,
+	log.PanicLevel: sentry.LevelFatal,
+}
+
+// sentryEventHook captures error-level logrus entries as Sentry issues via CaptureException, the
+// path recommended by sentry-go after NewEventHookFromClient was deprecated (removed in 0.48.0).
+// It preserves the previous behavior: error/fatal/panic logs still create Sentry issues (not just
+// structured logs, which is what NewLogHookFromClient would produce), carrying the entry's level
+// and fields.
+type sentryEventHook struct {
+	levels []log.Level
+}
+
+func newSentryEventHook(levels []log.Level) *sentryEventHook {
+	return &sentryEventHook{levels: levels}
+}
+
+func (h *sentryEventHook) Levels() []log.Level {
+	return h.levels
+}
+
+func (h *sentryEventHook) Fire(entry *log.Entry) error {
+	hub := sentry.CurrentHub().Clone()
+	hub.WithScope(func(scope *sentry.Scope) {
+		if level, ok := logrusToSentryLevel[entry.Level]; ok {
+			scope.SetLevel(level)
+		}
+		if len(entry.Data) > 0 {
+			fields := make(sentry.Context, len(entry.Data))
+			for key, value := range entry.Data {
+				fields[key] = value
+			}
+			scope.SetContext("logrus", fields)
+		}
+
+		if err, ok := entry.Data[log.ErrorKey].(error); ok && err != nil {
+			hub.CaptureException(err)
+			return
+		}
+		hub.CaptureMessage(entry.Message)
+	})
+	return nil
+}

--- a/utils/sentryEventHook.go
+++ b/utils/sentryEventHook.go
@@ -1,8 +1,16 @@
 package utils
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/getsentry/sentry-go"
 	log "github.com/sirupsen/logrus"
+)
+
+const (
+	sentryLoggerName  = "logrus"
+	defaultErrorDepth = 10
 )
 
 // logrusToSentryLevel maps the error-class logrus levels to Sentry levels.
@@ -12,11 +20,12 @@ var logrusToSentryLevel = map[log.Level]sentry.Level{
 	log.PanicLevel: sentry.LevelFatal,
 }
 
-// sentryEventHook captures error-level logrus entries as Sentry issues via CaptureException, the
-// path recommended by sentry-go after NewEventHookFromClient was deprecated (removed in 0.48.0).
-// It preserves the previous behavior: error/fatal/panic logs still create Sentry issues (not just
-// structured logs, which is what NewLogHookFromClient would produce), carrying the entry's level
-// and fields.
+// sentryEventHook captures error-level logrus entries as Sentry issues. It replaces
+// sentrylogrus.NewEventHookFromClient (deprecated in 0.47, removed in 0.48) with an equivalent
+// event builder, so error/fatal/panic logs still create issues rather than the structured logs
+// NewLogHookFromClient would produce. It preserves the fields the old hook promoted (request, user,
+// transaction, fingerprint), forwards remaining fields as tags, and forwards entry.Context via a
+// hint so attribution, grouping, and BeforeSend keep working.
 type sentryEventHook struct {
 	levels []log.Level
 }
@@ -30,24 +39,75 @@ func (h *sentryEventHook) Levels() []log.Level {
 }
 
 func (h *sentryEventHook) Fire(entry *log.Entry) error {
-	hub := sentry.CurrentHub().Clone()
-	hub.WithScope(func(scope *sentry.Scope) {
-		if level, ok := logrusToSentryLevel[entry.Level]; ok {
-			scope.SetLevel(level)
-		}
-		if len(entry.Data) > 0 {
-			fields := make(sentry.Context, len(entry.Data))
-			for key, value := range entry.Data {
-				fields[key] = value
-			}
-			scope.SetContext("logrus", fields)
-		}
+	event := entryToSentryEvent(entry)
 
-		if err, ok := entry.Data[log.ErrorKey].(error); ok && err != nil {
-			hub.CaptureException(err)
-			return
-		}
-		hub.CaptureMessage(entry.Message)
-	})
+	var hint *sentry.EventHint
+	if entry.Context != nil {
+		hint = &sentry.EventHint{Context: entry.Context}
+	}
+
+	sentry.CurrentHub().CaptureEventWithHint(event, hint)
 	return nil
+}
+
+func entryToSentryEvent(entry *log.Entry) *sentry.Event {
+	fields := make(log.Fields, len(entry.Data))
+	for key, value := range entry.Data {
+		fields[key] = value
+	}
+
+	event := sentry.NewEvent()
+	event.Level = logrusToSentryLevel[entry.Level]
+	event.Message = entry.Message
+	event.Timestamp = entry.Time
+	event.Logger = sentryLoggerName
+
+	switch request := fields["request"].(type) {
+	case *http.Request:
+		delete(fields, "request")
+		event.Request = sentry.NewRequest(request)
+	case sentry.Request:
+		delete(fields, "request")
+		event.Request = &request
+	case *sentry.Request:
+		delete(fields, "request")
+		event.Request = request
+	}
+
+	if err, ok := fields[log.ErrorKey].(error); ok && err != nil {
+		delete(fields, log.ErrorKey)
+		event.SetException(err, errorDepth())
+	}
+
+	switch user := fields["user"].(type) {
+	case sentry.User:
+		delete(fields, "user")
+		event.User = user
+	case *sentry.User:
+		delete(fields, "user")
+		event.User = *user
+	}
+
+	if transaction, ok := fields["transaction"].(string); ok {
+		delete(fields, "transaction")
+		event.Transaction = transaction
+	}
+
+	if fingerprint, ok := fields["fingerprint"].([]string); ok {
+		delete(fields, "fingerprint")
+		event.Fingerprint = fingerprint
+	}
+
+	for key, value := range fields {
+		event.Tags[key] = fmt.Sprint(value)
+	}
+
+	return event
+}
+
+func errorDepth() int {
+	if client := sentry.CurrentHub().Client(); client != nil {
+		return client.Options().MaxErrorDepth
+	}
+	return defaultErrorDepth
 }


### PR DESCRIPTION
## Summary

The `lint-sdk` pipeline has been red on `main` since the sentry-go 0.47 bump (#100): `sentrylogrus.NewEventHookFromClient` is deprecated (staticcheck `SA1019`) and will be removed in 0.48.0.

Replaces the deprecated event hook in `utils/initSentry.go` with a small logrus hook (`sentryEventHook`) that captures error/fatal/panic entries via `sentry.CaptureException` — the path sentry-go now recommends.

## Why not `NewLogHookFromClient`

The deprecation message points at `NewLogHookFromClient`, but that emits Sentry **structured logs**, not **issues**. The existing code deliberately used the event hook so error-level logs create Sentry issues (for alerting). The custom hook preserves that: error/fatal/panic logs still create issues, carrying the entry level and its fields (as a `logrus` context). Flush is handled via `sentry.Flush` on the logrus exit handler.

## Testing

- `go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass locally (lint now reports 0 issues).

This unblocks the `lint-go-code` check for the SDK library PRs (#105, #106, and the bootstrap PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reporting of application logs to Sentry with more accurate severity mapping.
  * Captures and forwards additional log context (including request/user/transaction details) as first-class Sentry event properties.
  * Error-related logs now attach exception details when available.
  * Ensures Sentry events are reliably flushed during application shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->