### PR TITLE
`Infrastructure`: Fix deprecated sentrylogrus event hook usage

### DIFF
--- a/utils/initSentry.go
+++ b/utils/initSentry.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"strconv"
 	"time"
 
@@ -8,6 +9,26 @@ import (
 	sentrylogrus "github.com/getsentry/sentry-go/logrus"
 	log "github.com/sirupsen/logrus"
 )
+
+// sentryEventHook forwards error-level logrus entries to Sentry as issues via CaptureException.
+// It replaces sentrylogrus.NewEventHookFromClient (deprecated in sentry-go 0.47, removed in 0.48),
+// which is the recommended migration: errors become issues via CaptureException while the log hook
+// keeps handling info/warn as structured logs. A plain level swap to the log hook would instead
+// downgrade errors from issues to structured logs.
+type sentryEventHook struct {
+	levels []log.Level
+}
+
+func (h *sentryEventHook) Levels() []log.Level { return h.levels }
+
+func (h *sentryEventHook) Fire(entry *log.Entry) error {
+	if err, ok := entry.Data[log.ErrorKey].(error); ok && err != nil {
+		sentry.CaptureException(err)
+		return nil
+	}
+	sentry.CaptureException(errors.New(entry.Message))
+	return nil
+}
 
 func InitSentry(sentryDsn string) error {
 	if sentryDsn == "" {
@@ -48,16 +69,15 @@ func InitSentry(sentryDsn string) error {
 		client,
 	)
 
-	eventHook := sentrylogrus.NewEventHookFromClient(
-		[]log.Level{log.ErrorLevel, log.FatalLevel, log.PanicLevel},
-		client,
-	)
+	eventHook := &sentryEventHook{
+		levels: []log.Level{log.ErrorLevel, log.FatalLevel, log.PanicLevel},
+	}
 
 	log.AddHook(logHook)
 	log.AddHook(eventHook)
 
 	log.RegisterExitHandler(func() {
-		eventHook.Flush(5 * time.Second)
+		sentry.Flush(5 * time.Second)
 		logHook.Flush(5 * time.Second)
 	})
 


### PR DESCRIPTION
## Summary

`sentry-go` 0.47 deprecated `sentrylogrus.NewEventHookFromClient` (removed in 0.48), which `utils/initSentry.go` uses to turn error-level logs into Sentry issues. This resolves the resulting `staticcheck` (`SA1019`) failure.

## Change

- Replace the deprecated event hook with a small logrus hook that captures `Error`/`Fatal`/`Panic` entries via `sentry.CaptureException` (the migration path Sentry recommends), so errors keep creating **issues**.
- The log hook still handles `Info`/`Warn` as structured logs.
- Deliberately **not** a plain level-swap onto `NewLogHookFromClient`: that routes error levels through Sentry's structured-logging API, downgrading errors from issues to logs.

## Testing

- `go build ./...`
- `go vet ./utils/`
- `golangci-lint run ./...` — 0 issues (previously 1 `SA1019`)