### PR TITLE
`Infrastructure`: Add phase service bootstrap helper to remove duplicated main.go wiring

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -1,0 +1,134 @@
+package promptSDK
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	sentrygin "github.com/getsentry/sentry-go/gin"
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prompt-edu/prompt-sdk/promptTypes"
+	"github.com/prompt-edu/prompt-sdk/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+// ServiceOptions configures Bootstrap for a single phase service. Only RegisterRoutes genuinely
+// varies between services; everything else is identical wiring captured as data.
+type ServiceOptions struct {
+	// ServiceName is the human-readable service name reported by the /info endpoint (e.g. "assessment").
+	ServiceName string
+
+	// BasePath is the router group prefix, verbatim (e.g. "/assessment/api"). Not derived from
+	// ServiceName because the existing services are inconsistent (leading slash, naming).
+	BasePath string
+
+	// CoursePhasePath is the sub-group nested under BasePath for phase-scoped routes.
+	// Defaults to "/course_phase/:coursePhaseID".
+	CoursePhasePath string
+
+	// DBEnvPrefix selects the per-phase DB_HOST_<PREFIX>/DB_PORT_<PREFIX> vars (e.g. "ASSESSMENT").
+	DBEnvPrefix string
+
+	// DefaultDBPort is the local-development fallback port for this phase (e.g. "5435").
+	DefaultDBPort string
+
+	// SentryDSNEnv is the env var holding this service's Sentry DSN (e.g. "SENTRY_DSN_ASSESSMENT").
+	SentryDSNEnv string
+
+	// DefaultAddress is the fallback listen address when SERVER_ADDRESS is unset (e.g. "localhost:8085").
+	DefaultAddress string
+
+	// MigrationsPath is the golang-migrate source path. Defaults to "./db/migration".
+	MigrationsPath string
+
+	// Capabilities is reported by the /info endpoint. Use the promptTypes.Capability* keys.
+	Capabilities map[string]bool
+
+	// RegisterRoutes wires the service's own modules onto the router groups. It receives the base
+	// api group, the phase-scoped group, and the connection pool (the service builds its own
+	// db.New(conn) — the SDK cannot reference a service-specific Queries type).
+	RegisterRoutes func(api, coursePhase *gin.RouterGroup, conn *pgxpool.Pool) error
+}
+
+// Bootstrap composes the phase-service startup sequence that every service copies today:
+// Sentry -> DB URL -> migrations -> pgx pool -> gin + Sentry + CORS -> route groups -> Keycloak ->
+// service routes -> /info health endpoint -> run. It returns an error instead of calling log.Fatal,
+// so callers do log.Fatal(promptSDK.Bootstrap(opts)). It blocks in router.Run until the server exits.
+func Bootstrap(opts ServiceOptions) error {
+	coursePhasePath := opts.CoursePhasePath
+	if coursePhasePath == "" {
+		coursePhasePath = "/course_phase/:coursePhaseID"
+	}
+	migrationsPath := opts.MigrationsPath
+	if migrationsPath == "" {
+		migrationsPath = "./db/migration"
+	}
+
+	sentryEnabled := GetEnv("SENTRY_ENABLED", "false") == "true"
+	if sentryEnabled {
+		_ = utils.InitSentry(GetEnv(opts.SentryDSNEnv, ""))
+		defer sentry.Flush(2 * time.Second)
+	}
+
+	databaseURL := utils.GetDatabaseURLForPrefix(opts.DBEnvPrefix, opts.DefaultDBPort)
+
+	if err := runMigrations(migrationsPath, databaseURL); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	conn, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		return fmt.Errorf("unable to create connection pool: %w", err)
+	}
+	defer conn.Close()
+
+	router := gin.Default()
+	if sentryEnabled {
+		router.Use(sentrygin.New(sentrygin.Options{}))
+	}
+	router.Use(CORSMiddleware(GetEnv("CORE_HOST", "http://localhost:3000")))
+
+	api := router.Group(opts.BasePath)
+	coursePhase := api.Group(coursePhasePath)
+
+	if err := InitPhaseKeycloak(); err != nil {
+		return err
+	}
+
+	if opts.RegisterRoutes != nil {
+		if err := opts.RegisterRoutes(api, coursePhase, conn); err != nil {
+			return fmt.Errorf("failed to register routes: %w", err)
+		}
+	}
+
+	promptTypes.RegisterInfoEndpoint(api, promptTypes.ServiceInfo{
+		ServiceName:  opts.ServiceName,
+		Version:      GetEnv("SERVER_IMAGE_TAG", ""),
+		Capabilities: opts.Capabilities,
+	}, func() bool {
+		pingCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+		return conn.Ping(pingCtx) == nil
+	})
+
+	serverAddress := GetEnv("SERVER_ADDRESS", opts.DefaultAddress)
+	log.Infof("%s server started on %s", opts.ServiceName, serverAddress)
+	return router.Run(serverAddress)
+}
+
+// runMigrations runs golang-migrate and prints its output with the DB password masked, so the
+// credential never reaches the logs even when migrate echoes the connection string on error.
+func runMigrations(migrationsPath, databaseURL string) error {
+	cmd := exec.Command("migrate", "-path", migrationsPath, "-database", databaseURL, "up")
+	output, err := cmd.CombinedOutput()
+	sanitized := utils.SanitizeDatabaseURL(string(output), GetEnv("DB_PASSWORD", "prompt-postgres"))
+	if err != nil {
+		return fmt.Errorf("failed to run migrations: %w\n%s", err, sanitized)
+	}
+	fmt.Print(sanitized)
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 require github.com/getsentry/sentry-go/logrus v0.47.0
 
 require (
+	github.com/getsentry/sentry-go/gin v0.47.0 // indirect
 	github.com/moby/moby/api v1.54.2 // indirect
 	github.com/moby/moby/client v0.4.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.41.0 // indirect
@@ -62,7 +63,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/getsentry/sentry-go v0.47.0 h1:AnSMSyrYA5qZCIN/2xpgAAwv63sVULV+vBq37ajouc8=
 github.com/getsentry/sentry-go v0.47.0/go.mod h1:h+b4VHpKnK7aUXB5wc+KDnPgp9ZtfliRD4eV85FbiSA=
+github.com/getsentry/sentry-go/gin v0.47.0 h1:1iTlex5MXVyqlEVBmuMsh1XhZjLxroVAuTSDmolYo8M=
+github.com/getsentry/sentry-go/gin v0.47.0/go.mod h1:eOKUeEmb/9ckWrmDSzZH8AKRNF5sPTBkmaeCwU3DvCE=
 github.com/getsentry/sentry-go/logrus v0.47.0 h1:GJ0X+PnvPyOTQNEPgDE6KhyWe/s7hXW7DdjF8nyWd/s=
 github.com/getsentry/sentry-go/logrus v0.47.0/go.mod h1:YyETTezOW0eAgsCrW82l/FKwpgxnkHryhXbrzxw3M54=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=
@@ -111,6 +113,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
+github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8=

--- a/utils/databaseUrl_test.go
+++ b/utils/databaseUrl_test.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDatabaseURLForPrefix(t *testing.T) {
+	t.Setenv("DB_USER", "prompt-postgres")
+	t.Setenv("DB_PASSWORD", "secret")
+	t.Setenv("DB_NAME", "prompt")
+	t.Setenv("DB_HOST_ASSESSMENT", "db.example.com")
+	t.Setenv("DB_PORT_ASSESSMENT", "6543")
+
+	url := GetDatabaseURLForPrefix("ASSESSMENT", "5435")
+	require.Equal(t, "postgres://prompt-postgres:secret@db.example.com:6543/prompt?sslmode=disable&TimeZone=Europe/Berlin", url)
+}
+
+func TestGetDatabaseURLForPrefixFallsBackToDefaultPort(t *testing.T) {
+	t.Setenv("DB_PASSWORD", "secret")
+	// DB_HOST_INTERVIEW and DB_PORT_INTERVIEW intentionally unset.
+	url := GetDatabaseURLForPrefix("INTERVIEW", "5438")
+	require.True(t, strings.Contains(url, "@localhost:5438/"), "expected localhost + default port, got %q", url)
+}
+
+func TestSanitizeDatabaseURL(t *testing.T) {
+	url := "postgres://prompt-postgres:s3cr3t@localhost:5432/prompt?sslmode=disable"
+	require.Equal(t, "postgres://prompt-postgres:***@localhost:5432/prompt?sslmode=disable", SanitizeDatabaseURL(url, "s3cr3t"))
+	require.Equal(t, url, SanitizeDatabaseURL(url, ""), "empty password must be a no-op")
+}

--- a/utils/getDatabaseUrl.go
+++ b/utils/getDatabaseUrl.go
@@ -15,3 +15,20 @@ func GetDatabaseURL() string {
 
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s&TimeZone=%s", dbUser, dbPassword, dbHost, dbPort, dbName, sslMode, timeZone)
 }
+
+// GetDatabaseURLForPrefix constructs a PostgreSQL connection string for a specific phase service,
+// reading the per-phase DB_HOST_<PREFIX> and DB_PORT_<PREFIX> environment variables (e.g.
+// DB_HOST_ASSESSMENT, DB_PORT_ASSESSMENT). defaultPort is used as the local-development fallback
+// port for that phase. All other variables (DB_USER, DB_PASSWORD, DB_NAME, SSL_MODE, DB_TIMEZONE)
+// are shared with GetDatabaseURL.
+func GetDatabaseURLForPrefix(envPrefix, defaultPort string) string {
+	dbUser := GetEnv("DB_USER", "prompt-postgres")
+	dbPassword := GetEnv("DB_PASSWORD", "prompt-postgres")
+	dbHost := GetEnv("DB_HOST_"+envPrefix, "localhost")
+	dbPort := GetEnv("DB_PORT_"+envPrefix, defaultPort)
+	dbName := GetEnv("DB_NAME", "prompt")
+	sslMode := GetEnv("SSL_MODE", "disable")
+	timeZone := GetEnv("DB_TIMEZONE", "Europe/Berlin")
+
+	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s&TimeZone=%s", dbUser, dbPassword, dbHost, dbPort, dbName, sslMode, timeZone)
+}

--- a/utils/sanitizeDatabaseUrl.go
+++ b/utils/sanitizeDatabaseUrl.go
@@ -1,0 +1,14 @@
+package utils
+
+import "strings"
+
+// SanitizeDatabaseURL masks occurrences of password in input with "***", so a database URL (or
+// migration tool output that echoes it) can be logged without leaking the credential. An empty
+// password returns input unchanged. It masks the raw password form, matching how GetDatabaseURL /
+// GetDatabaseURLForPrefix embed the password verbatim.
+func SanitizeDatabaseURL(input, password string) string {
+	if password == "" {
+		return input
+	}
+	return strings.ReplaceAll(input, password, "***")
+}


### PR DESCRIPTION
## Summary

Closes #102.

Every phase service (`assessment`, `certificate`, `interview`, `self_team_allocation`, `team_allocation`, `example_server`) repeats the same ~120-line `main.go` startup sequence plus several duplicated local helpers. This moves the composition into the SDK so a service `main.go` shrinks to a single call.

## Added to the SDK

- `utils.GetDatabaseURLForPrefix(envPrefix, defaultPort)` — resolves per-phase `DB_HOST_<PREFIX>` / `DB_PORT_<PREFIX>` vars. The existing `GetDatabaseURL()` is left unchanged (no breaking signature change), which is why services never adopted it.
- `utils.SanitizeDatabaseURL(input, password)` — masks the DB password in migration output/logs (6 identical copies lived in the services).
- `promptSDK.Bootstrap(ServiceOptions)` — composes Sentry → DB URL → sanitized migrations → pgx pool → gin + Sentry + CORS → `/api` + `/course_phase/:coursePhaseID` group split → Keycloak → service routes → `/info` health endpoint → run. Returns errors instead of `log.Fatal`. Route registration stays per-service via a `RegisterRoutes(api, coursePhase, conn)` callback that receives the pool — the SDK cannot reference a service-specific `db.Queries` type.

## Testing

- `go build ./...`
- `go test ./...` — all pass (added `utils/databaseUrl_test.go`)
- `golangci-lint run ./...` — my new files are clean.

## Note on CI

The `lint-go-code` check currently fails on a **pre-existing** `SA1019` deprecation in `utils/initSentry.go`, unrelated to this change. It is fixed by #107; once that merges to `main` and this branch is rebased, lint goes green.