### PR TITLE
Audit Log: Add shared audit package

### DIFF
--- a/audit/action.go
+++ b/audit/action.go
@@ -1,0 +1,53 @@
+package audit
+
+import "strings"
+
+var methodVerb = map[string]string{
+	"POST":   "Created",
+	"PUT":    "Updated",
+	"PATCH":  "Updated",
+	"DELETE": "Deleted",
+}
+
+func isMutating(method string) bool {
+	_, ok := methodVerb[method]
+	return ok
+}
+
+// deriveAction produces a readable-enough default label from the HTTP method
+// and the matched route template, e.g. ("POST", "/api/.../slots") -> "Created
+// slot". Developers override cryptic cases with audit.Describe.
+func deriveAction(method, routeTemplate string) string {
+	verb := methodVerb[method]
+	if verb == "" {
+		verb = method
+	}
+	resource := resourceFromTemplate(routeTemplate)
+	if resource == "" {
+		return verb
+	}
+	return verb + " " + resource
+}
+
+// resourceFromTemplate returns the last non-parameter path segment, humanized
+// (dashes/underscores to spaces, naive singularization).
+func resourceFromTemplate(routeTemplate string) string {
+	segments := strings.Split(routeTemplate, "/")
+	for i := len(segments) - 1; i >= 0; i-- {
+		seg := segments[i]
+		if seg == "" || strings.HasPrefix(seg, ":") || strings.HasPrefix(seg, "*") {
+			continue
+		}
+		seg = strings.ReplaceAll(seg, "-", " ")
+		seg = strings.ReplaceAll(seg, "_", " ")
+		return singularize(strings.ToLower(seg))
+	}
+	return ""
+}
+
+func singularize(word string) string {
+	if len(word) > 1 && strings.HasSuffix(word, "s") && !strings.HasSuffix(word, "ss") {
+		return strings.TrimSuffix(word, "s")
+	}
+	return word
+}

--- a/audit/action.go
+++ b/audit/action.go
@@ -46,7 +46,13 @@ func resourceFromTemplate(routeTemplate string) string {
 }
 
 func singularize(word string) string {
-	if len(word) > 1 && strings.HasSuffix(word, "s") && !strings.HasSuffix(word, "ss") {
+	// Only strip a trailing plural "s". Keep singular nouns that naturally end in
+	// "s" — double-s ("class"), "-us" ("status", "campus"), and "-is"
+	// ("analysis") — so route segments don't become "clas"/"statu"/"analysi".
+	if len(word) > 1 && strings.HasSuffix(word, "s") &&
+		!strings.HasSuffix(word, "ss") &&
+		!strings.HasSuffix(word, "us") &&
+		!strings.HasSuffix(word, "is") {
 		return strings.TrimSuffix(word, "s")
 	}
 	return word

--- a/audit/config.go
+++ b/audit/config.go
@@ -1,0 +1,11 @@
+package audit
+
+import "github.com/prompt-edu/prompt-sdk/utils"
+
+// Enabled reports whether audit logging is switched on for this service. It is
+// an administrator-controlled feature toggle: audit stays off unless
+// AUDIT_ENABLED is explicitly set to "true", so wiring the middleware in is
+// safe even before an admin turns it on.
+func Enabled() bool {
+	return utils.GetEnv("AUDIT_ENABLED", "") == "true"
+}

--- a/audit/context.go
+++ b/audit/context.go
@@ -1,0 +1,167 @@
+package audit
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/prompt-edu/prompt-sdk/keycloakTokenVerifier"
+)
+
+const (
+	runtimeContextKey  = "auditRuntime"
+	actionContextKey   = "auditAction"
+	skipContextKey     = "auditSkip"
+	recordedContextKey = "auditRecorded"
+)
+
+// Actor identifies the human who performed an action.
+type Actor struct {
+	ID    string
+	Name  string
+	Email string
+	Role  string
+	Roles []string
+}
+
+// ActorExtractor reads the authenticated actor from the request context. The
+// default reads the SDK TokenUser; core injects one reading its flat context
+// keys via WithActorExtractor.
+type ActorExtractor func(c *gin.Context) (Actor, bool)
+
+// runtime holds the per-service audit configuration, stashed in the gin context
+// by Middleware so Describe/Record can reach the sink.
+type runtime struct {
+	sink      Sink
+	extractor ActorExtractor
+	source    string
+}
+
+func (rt *runtime) write(e Event) {
+	if e.SourceService == "" {
+		e.SourceService = rt.source
+	}
+	go func() {
+		if err := rt.sink.Record(context.Background(), e); err != nil {
+			log.WithError(err).Error("audit: failed to record event")
+		}
+	}()
+}
+
+func runtimeFrom(c *gin.Context) (*runtime, bool) {
+	v, ok := c.Get(runtimeContextKey)
+	if !ok {
+		return nil, false
+	}
+	rt, ok := v.(*runtime)
+	return rt, ok
+}
+
+// Describe returns a route-scoped middleware that names the action for the
+// audited request, e.g. router.POST("/publish", audit.Describe("Published
+// grades"), handler). One line, declarative; the middleware emits a single
+// entry using this label.
+func Describe(label string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set(actionContextKey, label)
+	}
+}
+
+// Skip returns a route- or group-scoped middleware that excludes matching
+// requests from audit logging, e.g. api.Group("/sync", audit.Skip()).
+func Skip() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set(skipContextKey, true)
+	}
+}
+
+// Suppress excludes the current request from automatic audit logging. Call it
+// from a handler when a particular request should not be recorded (e.g. an
+// update that changed nothing).
+func Suppress(c *gin.Context) {
+	c.Set(skipContextKey, true)
+}
+
+// Record emits a fully-specified audit event from within a handler. It fills in
+// the actor, source service and HTTP context when left blank, and suppresses
+// the middleware's automatic backstop entry for this request so there is no
+// duplicate. Use it for high-stakes actions that need an EntityID/EntityName or
+// before/after Metadata, for multiple events per request, or for background
+// work (pass the initiating human's actor fields explicitly). Best-effort; for
+// atomic guarantees use the core RecordTx helper.
+func Record(c *gin.Context, e Event) {
+	rt, ok := runtimeFrom(c)
+	if !ok {
+		return
+	}
+	c.Set(recordedContextKey, true)
+
+	if e.ActorID == "" {
+		if actor, ok := rt.extractor(c); ok {
+			applyActor(&e, actor)
+		}
+	}
+	if e.Outcome == "" {
+		e.Outcome = OutcomeSuccess
+	}
+	if e.HTTPMethod == "" {
+		e.HTTPMethod = c.Request.Method
+	}
+	if e.HTTPPath == "" {
+		e.HTTPPath = c.FullPath()
+	}
+	if e.ActionKey == "" {
+		e.ActionKey = c.Request.Method + " " + c.FullPath()
+	}
+	rt.write(e)
+}
+
+func applyActor(e *Event, actor Actor) {
+	e.ActorID = actor.ID
+	e.ActorName = actor.Name
+	e.ActorEmail = actor.Email
+	e.ActorRole = actor.Role
+	e.ActorRoles = actor.Roles
+}
+
+// defaultActorExtractor reads the SDK TokenUser populated by the authentication
+// middleware. Used by phase services.
+func defaultActorExtractor(c *gin.Context) (Actor, bool) {
+	tu, ok := keycloakTokenVerifier.GetTokenUser(c)
+	if !ok || tu.ID == "" {
+		return Actor{}, false
+	}
+	roles := make([]string, 0, len(tu.Roles))
+	for role := range tu.Roles {
+		roles = append(roles, role)
+	}
+	return Actor{
+		ID:    tu.ID,
+		Name:  strings.TrimSpace(tu.FirstName + " " + tu.LastName),
+		Email: tu.Email,
+		Role:  primaryRole(tu.Roles),
+		Roles: roles,
+	}, true
+}
+
+// primaryRole picks the highest-privilege role present, used as the filterable
+// actor_role.
+func primaryRole(roles map[string]bool) string {
+	for _, role := range []string{
+		keycloakTokenVerifier.PromptAdmin,
+		keycloakTokenVerifier.PromptLecturer,
+		keycloakTokenVerifier.CourseLecturer,
+		keycloakTokenVerifier.CourseEditor,
+		keycloakTokenVerifier.CourseStudent,
+	} {
+		if roles[role] {
+			return role
+		}
+	}
+	for role := range roles {
+		return role
+	}
+	return ""
+}

--- a/audit/context.go
+++ b/audit/context.go
@@ -31,23 +31,37 @@ type Actor struct {
 // keys via WithActorExtractor.
 type ActorExtractor func(c *gin.Context) (Actor, bool)
 
+// maxConcurrentDeliveries bounds how many audit events may be in flight to the
+// sink at once. Delivery is best-effort: when the limit is reached (e.g. a slow
+// or unreachable core, whose HTTP sink retries for ~30s per event), further
+// events are dropped with a logged warning rather than spawning unbounded
+// goroutines.
+const maxConcurrentDeliveries = 64
+
 // runtime holds the per-service audit configuration, stashed in the gin context
 // by Middleware so Describe/Record can reach the sink.
 type runtime struct {
 	sink      Sink
 	extractor ActorExtractor
 	source    string
+	sem       chan struct{}
 }
 
 func (rt *runtime) write(e Event) {
 	if e.SourceService == "" {
 		e.SourceService = rt.source
 	}
-	go func() {
-		if err := rt.sink.Record(context.Background(), e); err != nil {
-			log.WithError(err).Error("audit: failed to record event")
-		}
-	}()
+	select {
+	case rt.sem <- struct{}{}:
+		go func() {
+			defer func() { <-rt.sem }()
+			if err := rt.sink.Record(context.Background(), e); err != nil {
+				log.WithError(err).Error("audit: failed to record event")
+			}
+		}()
+	default:
+		log.Warn("audit: delivery concurrency limit reached, dropping audit event")
+	}
 }
 
 func runtimeFrom(c *gin.Context) (*runtime, bool) {
@@ -96,13 +110,19 @@ func Record(c *gin.Context, e Event) {
 	if !ok {
 		return
 	}
+
+	// Every audited action must trace to a human. If no actor is supplied and
+	// none can be extracted, do not record — and do not suppress the automatic
+	// backstop, so a later-resolvable actor can still be captured.
+	if e.ActorID == "" {
+		actor, ok := rt.extractor(c)
+		if !ok {
+			return
+		}
+		applyActor(&e, actor)
+	}
 	c.Set(recordedContextKey, true)
 
-	if e.ActorID == "" {
-		if actor, ok := rt.extractor(c); ok {
-			applyActor(&e, actor)
-		}
-	}
 	if e.Outcome == "" {
 		e.Outcome = OutcomeSuccess
 	}

--- a/audit/context.go
+++ b/audit/context.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -157,6 +158,7 @@ func defaultActorExtractor(c *gin.Context) (Actor, bool) {
 	for role := range tu.Roles {
 		roles = append(roles, role)
 	}
+	sort.Strings(roles) // stable order (map iteration is randomized)
 	return Actor{
 		ID:    tu.ID,
 		Name:  strings.TrimSpace(tu.FirstName + " " + tu.LastName),
@@ -180,8 +182,13 @@ func primaryRole(roles map[string]bool) string {
 			return role
 		}
 	}
+	// No known role: pick the lexicographically smallest so the value is stable
+	// across requests (map iteration order is randomized).
+	fallback := ""
 	for role := range roles {
-		return role
+		if fallback == "" || role < fallback {
+			fallback = role
+		}
 	}
-	return ""
+	return fallback
 }

--- a/audit/context.go
+++ b/audit/context.go
@@ -16,6 +16,9 @@ const (
 	actionContextKey   = "auditAction"
 	skipContextKey     = "auditSkip"
 	recordedContextKey = "auditRecorded"
+	// recordedEventsKey holds the []Event buffered by in-request Record calls,
+	// flushed by the middleware after the handler returns (see flushRecordedEvents).
+	recordedEventsKey = "auditRecordedEvents"
 )
 
 // Actor identifies the human who performed an action.
@@ -61,7 +64,11 @@ func (rt *runtime) write(e Event) {
 			}
 		}()
 	default:
-		log.Warn("audit: delivery concurrency limit reached, dropping audit event")
+		// Best-effort delivery: when the in-flight limit is reached (e.g. core is
+		// unreachable and every slot is blocked on retries) the event is dropped.
+		// Log the action and actor so the gap is at least reconstructible.
+		log.WithFields(log.Fields{"action": e.Action, "actorID": e.ActorID}).
+			Warn("audit: delivery concurrency limit reached, dropping audit event")
 	}
 }
 
@@ -100,12 +107,22 @@ func Suppress(c *gin.Context) {
 }
 
 // Record emits a fully-specified audit event from within a handler. It fills in
-// the actor, source service and HTTP context when left blank, and suppresses
-// the middleware's automatic backstop entry for this request so there is no
-// duplicate. Use it for high-stakes actions that need an EntityID/EntityName or
-// before/after Metadata, for multiple events per request, or for background
-// work (pass the initiating human's actor fields explicitly). Best-effort; for
-// atomic guarantees use the core RecordTx helper.
+// the actor, action label, source service and HTTP context when left blank, and
+// suppresses the middleware's automatic backstop entry for this request so there
+// is no duplicate. Use it for high-stakes actions that need an EntityID/
+// EntityName or before/after Metadata, or for multiple events per request.
+//
+// Outcome/status handling: when Outcome is left blank (the common "record, then
+// do the work" case) the event is buffered and flushed by the middleware after
+// the handler returns, so it carries the request's real final status and outcome
+// rather than a premature success. When Outcome is set explicitly — e.g. a
+// background job that has already completed and reports its own result — the
+// event is delivered immediately.
+//
+// For background work, do NOT hand this the live *gin.Context: gin recycles it
+// into a pool once the handler returns. Pass c.Copy() (and set the actor fields
+// and Outcome explicitly). Best-effort; for atomic guarantees use the core
+// RecordTx helper.
 func Record(c *gin.Context, e Event) {
 	rt, ok := runtimeFrom(c)
 	if !ok {
@@ -124,9 +141,6 @@ func Record(c *gin.Context, e Event) {
 	}
 	c.Set(recordedContextKey, true)
 
-	if e.Outcome == "" {
-		e.Outcome = OutcomeSuccess
-	}
 	if e.HTTPMethod == "" {
 		e.HTTPMethod = c.Request.Method
 	}
@@ -136,7 +150,53 @@ func Record(c *gin.Context, e Event) {
 	if e.ActionKey == "" {
 		e.ActionKey = c.Request.Method + " " + c.FullPath()
 	}
-	rt.write(e)
+	if e.Action == "" {
+		e.Action = actionLabel(c, c.Request.Method, c.FullPath())
+	}
+	// Marshalling happens asynchronously; snapshot the caller's map so a handler
+	// that keeps mutating Metadata after Record does not race the delivery.
+	if e.Metadata != nil {
+		e.Metadata = cloneMetadata(e.Metadata)
+	}
+
+	// Explicit outcome => deliver now (background/final event). No outcome yet =>
+	// buffer and let the middleware stamp the real status/outcome after c.Next().
+	if e.Outcome != "" {
+		rt.write(e)
+		return
+	}
+	bufferEvent(c, e)
+}
+
+// bufferEvent appends an in-request event to the per-request buffer flushed by
+// the middleware after the handler returns.
+func bufferEvent(c *gin.Context, e Event) {
+	var buf []Event
+	if v, ok := c.Get(recordedEventsKey); ok {
+		if existing, ok := v.([]Event); ok {
+			buf = existing
+		}
+	}
+	c.Set(recordedEventsKey, append(buf, e))
+}
+
+// actionLabel returns the explicit Describe label if one was set for the route,
+// otherwise the derived default. Shared by Record and the middleware backstop.
+func actionLabel(c *gin.Context, method, routeTemplate string) string {
+	if label, ok := c.Get(actionContextKey); ok {
+		if s, ok := label.(string); ok && s != "" {
+			return s
+		}
+	}
+	return deriveAction(method, routeTemplate)
+}
+
+func cloneMetadata(m map[string]any) map[string]any {
+	cp := make(map[string]any, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
 }
 
 func applyActor(e *Event, actor Actor) {
@@ -169,17 +229,25 @@ func defaultActorExtractor(c *gin.Context) (Actor, bool) {
 }
 
 // primaryRole picks the highest-privilege role present, used as the filterable
-// actor_role.
+// actor_role. The platform roles are matched exactly, but course roles arrive
+// course-prefixed (e.g. "ios24-Lecturer"), so they are matched by suffix — the
+// same scheme the SDK auth middleware uses.
 func primaryRole(roles map[string]bool) string {
-	for _, role := range []string{
-		keycloakTokenVerifier.PromptAdmin,
-		keycloakTokenVerifier.PromptLecturer,
+	if roles[keycloakTokenVerifier.PromptAdmin] {
+		return keycloakTokenVerifier.PromptAdmin
+	}
+	if roles[keycloakTokenVerifier.PromptLecturer] {
+		return keycloakTokenVerifier.PromptLecturer
+	}
+	for _, courseRole := range []string{
 		keycloakTokenVerifier.CourseLecturer,
 		keycloakTokenVerifier.CourseEditor,
 		keycloakTokenVerifier.CourseStudent,
 	} {
-		if roles[role] {
-			return role
+		for userRole := range roles {
+			if strings.HasSuffix(userRole, courseRole) {
+				return courseRole
+			}
 		}
 	}
 	// No known role: pick the lexicographically smallest so the value is stable

--- a/audit/event.go
+++ b/audit/event.go
@@ -1,0 +1,57 @@
+// Package audit provides a unified, low-effort audit-logging API shared by the
+// core service and every course phase microservice. Services register a single
+// Gin middleware that automatically captures mutating requests; developers may
+// additionally name events with Describe, emit rich or background events with
+// Record, or opt out with Skip/Suppress. Only the Sink (how an entry is
+// persisted) differs per service: core inserts into its own database, phases
+// ship entries to core over HTTP.
+package audit
+
+import "context"
+
+// Outcome values distinguish a successful action from a denied attempt.
+const (
+	OutcomeSuccess = "success"
+	OutcomeDenied  = "denied"
+)
+
+// Event is the neutral, transport-agnostic audit record. The same struct is
+// produced by the auto-capture middleware and by explicit Record calls, and is
+// consumed by every Sink implementation.
+type Event struct {
+	// Actor — who performed the action. In PROMPT every action traces to a
+	// human; background work carries the initiating human's identity.
+	ActorID    string   `json:"actorID"`
+	ActorName  string   `json:"actorName"`
+	ActorEmail string   `json:"actorEmail"`
+	ActorRoles []string `json:"actorRoles"`
+	ActorRole  string   `json:"actorRole"`
+
+	// What happened.
+	Action     string `json:"action"`     // human-readable, e.g. "Created slot"
+	ActionKey  string `json:"actionKey"`  // machine key, e.g. "POST /api/.../slots"
+	Outcome    string `json:"outcome"`    // OutcomeSuccess | OutcomeDenied
+	EntityType string `json:"entityType"` // optional
+	EntityID   string `json:"entityID"`   // optional
+	EntityName string `json:"entityName"` // snapshotted human-readable subject
+
+	// Where.
+	CourseID      string `json:"courseID"`      // optional; null => admin-only
+	CoursePhaseID string `json:"coursePhaseID"` // optional
+	SourceService string `json:"sourceService"` // "core", "interview", ...
+
+	// HTTP context (empty for non-request events).
+	HTTPMethod string `json:"httpMethod"`
+	HTTPPath   string `json:"httpPath"`
+	HTTPStatus int    `json:"httpStatus"`
+
+	// Metadata holds identifiers and change summaries — never raw sensitive
+	// payloads (grade values, note contents).
+	Metadata map[string]any `json:"metadata"`
+}
+
+// Sink persists an audit Event. It is a small consumer-side interface: core
+// provides a database-backed sink, phases provide an HTTP sink (NewCoreSink).
+type Sink interface {
+	Record(ctx context.Context, e Event) error
+}

--- a/audit/event.go
+++ b/audit/event.go
@@ -9,10 +9,12 @@ package audit
 
 import "context"
 
-// Outcome values distinguish a successful action from a denied attempt.
+// Outcome values distinguish a successful action, a denied attempt, and an
+// action whose request ultimately errored.
 const (
 	OutcomeSuccess = "success"
 	OutcomeDenied  = "denied"
+	OutcomeError   = "error"
 )
 
 // Event is the neutral, transport-agnostic audit record. The same struct is
@@ -30,7 +32,7 @@ type Event struct {
 	// What happened.
 	Action     string `json:"action"`     // human-readable, e.g. "Created slot"
 	ActionKey  string `json:"actionKey"`  // machine key, e.g. "POST /api/.../slots"
-	Outcome    string `json:"outcome"`    // OutcomeSuccess | OutcomeDenied
+	Outcome    string `json:"outcome"`    // OutcomeSuccess | OutcomeDenied | OutcomeError
 	EntityType string `json:"entityType"` // optional
 	EntityID   string `json:"entityID"`   // optional
 	EntityName string `json:"entityName"` // snapshotted human-readable subject

--- a/audit/middleware.go
+++ b/audit/middleware.go
@@ -1,0 +1,105 @@
+package audit
+
+import "github.com/gin-gonic/gin"
+
+// Option configures the audit middleware.
+type Option func(*runtime)
+
+// WithActorExtractor overrides how the actor is read from the request context.
+// Core passes an extractor that reads its flat context keys; phases use the
+// default (SDK TokenUser).
+func WithActorExtractor(extractor ActorExtractor) Option {
+	return func(rt *runtime) {
+		if extractor != nil {
+			rt.extractor = extractor
+		}
+	}
+}
+
+// WithSourceService sets the source_service stamped on locally-persisted events
+// (core uses "core"). For phases shipping over HTTP, core overrides it from the
+// authenticated service identity, so it may be left empty.
+func WithSourceService(name string) Option {
+	return func(rt *runtime) {
+		rt.source = name
+	}
+}
+
+// Middleware returns a Gin middleware that automatically records mutating
+// requests through sink. It must run after the route's auth middleware. A
+// request is recorded only when it uses a mutating method (POST/PUT/PATCH/
+// DELETE), resolves to a known actor, is not suppressed, and either succeeded
+// (2xx -> success) or was denied (403 -> denied); other statuses are ignored.
+// Passing a nil sink returns a pass-through no-op, so a service can register the
+// middleware unconditionally and let the feature toggle decide.
+func Middleware(sink Sink, opts ...Option) gin.HandlerFunc {
+	if sink == nil {
+		return func(c *gin.Context) { c.Next() }
+	}
+	rt := &runtime{sink: sink, extractor: defaultActorExtractor}
+	for _, opt := range opts {
+		opt(rt)
+	}
+
+	return func(c *gin.Context) {
+		c.Set(runtimeContextKey, rt)
+		c.Next()
+
+		if c.GetBool(skipContextKey) || c.GetBool(recordedContextKey) {
+			return
+		}
+		outcome, ok := outcomeForStatus(c.Writer.Status())
+		if !ok || !isMutating(c.Request.Method) {
+			return
+		}
+		actor, ok := rt.extractor(c)
+		if !ok {
+			return
+		}
+		rt.write(buildEvent(c, actor, outcome))
+	}
+}
+
+func outcomeForStatus(status int) (string, bool) {
+	switch {
+	case status >= 200 && status < 300:
+		return OutcomeSuccess, true
+	case status == 403:
+		return OutcomeDenied, true
+	default:
+		return "", false
+	}
+}
+
+func buildEvent(c *gin.Context, actor Actor, outcome string) Event {
+	routeTemplate := c.FullPath()
+	action := deriveAction(c.Request.Method, routeTemplate)
+	if label, ok := c.Get(actionContextKey); ok {
+		if s, ok := label.(string); ok && s != "" {
+			action = s
+		}
+	}
+
+	e := Event{
+		Action:        action,
+		ActionKey:     c.Request.Method + " " + routeTemplate,
+		Outcome:       outcome,
+		CourseID:      firstParam(c, "courseId", "courseID"),
+		CoursePhaseID: c.Param("coursePhaseID"),
+		EntityID:      firstParam(c, "uuid", "id"),
+		HTTPMethod:    c.Request.Method,
+		HTTPPath:      routeTemplate,
+		HTTPStatus:    c.Writer.Status(),
+	}
+	applyActor(&e, actor)
+	return e
+}
+
+func firstParam(c *gin.Context, names ...string) string {
+	for _, name := range names {
+		if v := c.Param(name); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/audit/middleware.go
+++ b/audit/middleware.go
@@ -49,6 +49,12 @@ func Middleware(sink Sink, opts ...Option) gin.HandlerFunc {
 		c.Set(runtimeContextKey, rt)
 		c.Next()
 
+		// Flush events buffered by in-request Record calls first, stamping the
+		// real final status/outcome. These are honored even when Skip/Suppress is
+		// set — those only silence the automatic backstop, not events the
+		// developer asked for explicitly.
+		flushRecordedEvents(c, rt)
+
 		if c.GetBool(skipContextKey) || c.GetBool(recordedContextKey) {
 			return
 		}
@@ -64,28 +70,59 @@ func Middleware(sink Sink, opts ...Option) gin.HandlerFunc {
 	}
 }
 
+// flushRecordedEvents delivers the events Record buffered during the request,
+// now that the final HTTP status is known.
+func flushRecordedEvents(c *gin.Context, rt *runtime) {
+	v, ok := c.Get(recordedEventsKey)
+	if !ok {
+		return
+	}
+	events, ok := v.([]Event)
+	if !ok {
+		return
+	}
+	status := c.Writer.Status()
+	for _, e := range events {
+		if e.HTTPStatus == 0 {
+			e.HTTPStatus = status
+		}
+		if e.Outcome == "" {
+			e.Outcome = outcomeFor(status)
+		}
+		rt.write(e)
+	}
+}
+
+// outcomeForStatus classifies a status for the automatic backstop, which only
+// records clear successes (2xx) and denials. Denials abort with 403 in core's
+// permission middleware and 401 in the SDK auth middleware; both count, and the
+// actor gate filters out unauthenticated 401s (no resolvable actor).
 func outcomeForStatus(status int) (string, bool) {
 	switch {
 	case status >= 200 && status < 300:
 		return OutcomeSuccess, true
-	case status == 403:
+	case status == 401 || status == 403:
 		return OutcomeDenied, true
 	default:
 		return "", false
 	}
 }
 
+// outcomeFor is the total version used when flushing an explicit event: an
+// unclassified status (e.g. a 5xx after "record, then do the work") is recorded
+// as an error rather than a false success.
+func outcomeFor(status int) string {
+	if o, ok := outcomeForStatus(status); ok {
+		return o
+	}
+	return OutcomeError
+}
+
 func buildEvent(c *gin.Context, actor Actor, outcome string) Event {
 	routeTemplate := c.FullPath()
-	action := deriveAction(c.Request.Method, routeTemplate)
-	if label, ok := c.Get(actionContextKey); ok {
-		if s, ok := label.(string); ok && s != "" {
-			action = s
-		}
-	}
 
 	e := Event{
-		Action:        action,
+		Action:        actionLabel(c, c.Request.Method, routeTemplate),
 		ActionKey:     c.Request.Method + " " + routeTemplate,
 		Outcome:       outcome,
 		CourseID:      firstParam(c, "courseId", "courseID"),

--- a/audit/middleware.go
+++ b/audit/middleware.go
@@ -36,7 +36,11 @@ func Middleware(sink Sink, opts ...Option) gin.HandlerFunc {
 	if sink == nil {
 		return func(c *gin.Context) { c.Next() }
 	}
-	rt := &runtime{sink: sink, extractor: defaultActorExtractor}
+	rt := &runtime{
+		sink:      sink,
+		extractor: defaultActorExtractor,
+		sem:       make(chan struct{}, maxConcurrentDeliveries),
+	}
 	for _, opt := range opts {
 		opt(rt)
 	}

--- a/audit/middleware_test.go
+++ b/audit/middleware_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -73,12 +74,28 @@ func newWaitSink(n int) (waitSink, *sync.WaitGroup) {
 	return waitSink{fakeSink: &fakeSink{}, wg: wg}, wg
 }
 
+// waitOrFail waits for the expected async deliveries, failing the test instead
+// of hanging if they never arrive.
+func waitOrFail(t *testing.T, wg *sync.WaitGroup) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for audit event delivery")
+	}
+}
+
 func TestMiddleware_LogsSuccessfulMutation(t *testing.T) {
 	sink, wg := newWaitSink(1)
 	run(t, sink, http.MethodPost, "/api/course_phase/p1/slots", func(r *gin.Engine) {
 		r.POST("/api/course_phase/:coursePhaseID/slots", func(c *gin.Context) { c.Status(http.StatusCreated) })
 	})
-	wg.Wait()
+	waitOrFail(t, wg)
 
 	events := sink.all()
 	require.Len(t, events, 1)
@@ -97,7 +114,7 @@ func TestMiddleware_LogsDeniedAs403(t *testing.T) {
 	run(t, sink, http.MethodDelete, "/api/teams/t1", func(r *gin.Engine) {
 		r.DELETE("/api/teams/:uuid", func(c *gin.Context) { c.Status(http.StatusForbidden) })
 	})
-	wg.Wait()
+	waitOrFail(t, wg)
 
 	events := sink.all()
 	require.Len(t, events, 1)
@@ -136,7 +153,7 @@ func TestMiddleware_DescribeOverridesLabel(t *testing.T) {
 	run(t, sink, http.MethodPost, "/api/courses/c1/copy", func(r *gin.Engine) {
 		r.POST("/api/courses/:courseId/copy", Describe("Copied course"), func(c *gin.Context) { c.Status(http.StatusOK) })
 	})
-	wg.Wait()
+	waitOrFail(t, wg)
 
 	events := sink.all()
 	require.Len(t, events, 1)
@@ -171,7 +188,7 @@ func TestRecord_AutoSuppressesBackstop(t *testing.T) {
 			c.Status(http.StatusOK)
 		})
 	})
-	wg.Wait()
+	waitOrFail(t, wg)
 
 	events := sink.all()
 	require.Len(t, events, 1) // exactly one: the explicit Record, not the backstop
@@ -189,7 +206,7 @@ func TestRecord_StillWritesWhenSuppressed(t *testing.T) {
 			c.Status(http.StatusOK)
 		})
 	})
-	wg.Wait()
+	waitOrFail(t, wg)
 
 	events := sink.all()
 	require.Len(t, events, 1)
@@ -207,7 +224,7 @@ func TestMiddleware_CapturesDenialFromAbortingMiddleware(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/course_phase/p1/grades", nil)
 	r.ServeHTTP(httptest.NewRecorder(), req)
-	wg.Wait()
+	waitOrFail(t, wg)
 
 	events := sink.all()
 	require.Len(t, events, 1)

--- a/audit/middleware_test.go
+++ b/audit/middleware_test.go
@@ -1,0 +1,251 @@
+package audit
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSink captures events synchronously for assertions.
+type fakeSink struct {
+	mu     sync.Mutex
+	events []Event
+}
+
+func (f *fakeSink) Record(_ context.Context, e Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, e)
+	return nil
+}
+
+func (f *fakeSink) all() []Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]Event, len(f.events))
+	copy(out, f.events)
+	return out
+}
+
+func staticActor(c *gin.Context) (Actor, bool) {
+	if c.GetBool("noActor") {
+		return Actor{}, false
+	}
+	return Actor{ID: "u1", Name: "Ada Lovelace", Email: "ada@tum.de", Role: "Lecturer", Roles: []string{"Lecturer"}}, true
+}
+
+// run executes a single request through a router with the audit middleware and
+// returns the events the sink saw. The middleware writes in a background
+// goroutine, so we wait on a WaitGroup toggled by a wrapper sink.
+func run(t *testing.T, sink Sink, method, path string, register func(r *gin.Engine)) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Middleware(sink, WithActorExtractor(staticActor), WithSourceService("core")))
+	register(r)
+
+	req := httptest.NewRequest(method, path, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+}
+
+// waitSink blocks in Record until released, letting tests deterministically
+// observe the async write.
+type waitSink struct {
+	*fakeSink
+	wg *sync.WaitGroup
+}
+
+func (s waitSink) Record(ctx context.Context, e Event) error {
+	defer s.wg.Done()
+	return s.fakeSink.Record(ctx, e)
+}
+
+func newWaitSink(n int) (waitSink, *sync.WaitGroup) {
+	wg := &sync.WaitGroup{}
+	wg.Add(n)
+	return waitSink{fakeSink: &fakeSink{}, wg: wg}, wg
+}
+
+func TestMiddleware_LogsSuccessfulMutation(t *testing.T) {
+	sink, wg := newWaitSink(1)
+	run(t, sink, http.MethodPost, "/api/course_phase/p1/slots", func(r *gin.Engine) {
+		r.POST("/api/course_phase/:coursePhaseID/slots", func(c *gin.Context) { c.Status(http.StatusCreated) })
+	})
+	wg.Wait()
+
+	events := sink.all()
+	require.Len(t, events, 1)
+	e := events[0]
+	assert.Equal(t, OutcomeSuccess, e.Outcome)
+	assert.Equal(t, "Created slot", e.Action)
+	assert.Equal(t, "POST /api/course_phase/:coursePhaseID/slots", e.ActionKey)
+	assert.Equal(t, "p1", e.CoursePhaseID)
+	assert.Equal(t, "u1", e.ActorID)
+	assert.Equal(t, "Lecturer", e.ActorRole)
+	assert.Equal(t, "core", e.SourceService)
+}
+
+func TestMiddleware_LogsDeniedAs403(t *testing.T) {
+	sink, wg := newWaitSink(1)
+	run(t, sink, http.MethodDelete, "/api/teams/t1", func(r *gin.Engine) {
+		r.DELETE("/api/teams/:uuid", func(c *gin.Context) { c.Status(http.StatusForbidden) })
+	})
+	wg.Wait()
+
+	events := sink.all()
+	require.Len(t, events, 1)
+	assert.Equal(t, OutcomeDenied, events[0].Outcome)
+	assert.Equal(t, "t1", events[0].EntityID)
+	assert.Equal(t, "Deleted team", events[0].Action)
+}
+
+func TestMiddleware_SkipsReadsAndNoise(t *testing.T) {
+	for _, tc := range []struct {
+		name, method string
+		status       int
+		noActor      bool
+	}{
+		{"GET read", http.MethodGet, http.StatusOK, false},
+		{"401 unauth", http.MethodPost, http.StatusUnauthorized, false},
+		{"404 not found", http.MethodPost, http.StatusNotFound, false},
+		{"422 validation", http.MethodPost, http.StatusUnprocessableEntity, false},
+		{"no actor", http.MethodPost, http.StatusCreated, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &fakeSink{}
+			run(t, sink, tc.method, "/api/things", func(r *gin.Engine) {
+				r.Handle(tc.method, "/api/things", func(c *gin.Context) {
+					c.Set("noActor", tc.noActor)
+					c.Status(tc.status)
+				})
+			})
+			assert.Empty(t, sink.all())
+		})
+	}
+}
+
+func TestMiddleware_DescribeOverridesLabel(t *testing.T) {
+	sink, wg := newWaitSink(1)
+	run(t, sink, http.MethodPost, "/api/courses/c1/copy", func(r *gin.Engine) {
+		r.POST("/api/courses/:courseId/copy", Describe("Copied course"), func(c *gin.Context) { c.Status(http.StatusOK) })
+	})
+	wg.Wait()
+
+	events := sink.all()
+	require.Len(t, events, 1)
+	assert.Equal(t, "Copied course", events[0].Action)
+	assert.Equal(t, "c1", events[0].CourseID)
+}
+
+func TestMiddleware_SkipPreventsEntry(t *testing.T) {
+	sink := &fakeSink{}
+	run(t, sink, http.MethodPost, "/api/sync/pull", func(r *gin.Engine) {
+		r.POST("/api/sync/pull", Skip(), func(c *gin.Context) { c.Status(http.StatusOK) })
+	})
+	assert.Empty(t, sink.all())
+}
+
+func TestMiddleware_SuppressPreventsEntry(t *testing.T) {
+	sink := &fakeSink{}
+	run(t, sink, http.MethodPost, "/api/noop", func(r *gin.Engine) {
+		r.POST("/api/noop", func(c *gin.Context) {
+			Suppress(c)
+			c.Status(http.StatusOK)
+		})
+	})
+	assert.Empty(t, sink.all())
+}
+
+func TestRecord_AutoSuppressesBackstop(t *testing.T) {
+	sink, wg := newWaitSink(1)
+	run(t, sink, http.MethodPost, "/api/grades", func(r *gin.Engine) {
+		r.POST("/api/grades", func(c *gin.Context) {
+			Record(c, Event{Action: "Published grades", EntityType: "grade", EntityID: "g1", EntityName: "team Alpha"})
+			c.Status(http.StatusOK)
+		})
+	})
+	wg.Wait()
+
+	events := sink.all()
+	require.Len(t, events, 1) // exactly one: the explicit Record, not the backstop
+	assert.Equal(t, "Published grades", events[0].Action)
+	assert.Equal(t, "team Alpha", events[0].EntityName)
+	assert.Equal(t, "u1", events[0].ActorID) // actor filled from extractor
+}
+
+func TestRecord_StillWritesWhenSuppressed(t *testing.T) {
+	sink, wg := newWaitSink(1)
+	run(t, sink, http.MethodPost, "/api/thing", func(r *gin.Engine) {
+		r.POST("/api/thing", func(c *gin.Context) {
+			Suppress(c) // silences the backstop
+			Record(c, Event{Action: "Did the thing on purpose"})
+			c.Status(http.StatusOK)
+		})
+	})
+	wg.Wait()
+
+	events := sink.all()
+	require.Len(t, events, 1)
+	assert.Equal(t, "Did the thing on purpose", events[0].Action)
+}
+
+func TestMiddleware_NilSinkIsNoOp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Middleware(nil))
+	called := false
+	r.POST("/api/thing", func(c *gin.Context) { called = true; c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodPost, "/api/thing", nil)
+	r.ServeHTTP(httptest.NewRecorder(), req)
+	assert.True(t, called)
+}
+
+func TestEnabled(t *testing.T) {
+	t.Setenv("AUDIT_ENABLED", "true")
+	assert.True(t, Enabled())
+	t.Setenv("AUDIT_ENABLED", "")
+	assert.False(t, Enabled())
+}
+
+func TestNewCoreSink_DisabledReturnsNil(t *testing.T) {
+	t.Setenv("AUDIT_ENABLED", "true")
+	t.Setenv("AUDIT_INGEST_KEY", "")
+	assert.Nil(t, NewCoreSink("http://core", "interview"))
+
+	t.Setenv("AUDIT_ENABLED", "")
+	t.Setenv("AUDIT_INGEST_KEY", "secret")
+	assert.Nil(t, NewCoreSink("http://core", "interview"))
+}
+
+func TestNewCoreSink_SendsHeaders(t *testing.T) {
+	t.Setenv("AUDIT_ENABLED", "true")
+	t.Setenv("AUDIT_INGEST_KEY", "secret")
+
+	var gotService, gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotService = r.Header.Get("X-Audit-Service")
+		gotToken = r.Header.Get("X-Audit-Token")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	sink := NewCoreSink(srv.URL, "interview")
+	require.NotNil(t, sink)
+	require.NoError(t, sink.Record(context.Background(), Event{Action: "Created slot"}))
+	assert.Equal(t, "interview", gotService)
+	assert.Equal(t, "secret", gotToken)
+}
+
+func TestDeriveAction(t *testing.T) {
+	assert.Equal(t, "Created slot", deriveAction("POST", "/api/course_phase/:id/slots"))
+	assert.Equal(t, "Updated participation", deriveAction("PATCH", "/api/.../participations"))
+	assert.Equal(t, "Deleted team", deriveAction("DELETE", "/api/teams/:uuid"))
+}

--- a/audit/middleware_test.go
+++ b/audit/middleware_test.go
@@ -292,6 +292,21 @@ func TestNewCoreSink_SendsHeaders(t *testing.T) {
 	assert.Equal(t, "secret", gotToken)
 }
 
+func TestInsecureExternalURL(t *testing.T) {
+	for in, want := range map[string]bool{
+		"https://core.example.com": false, // TLS
+		"http://server-core:8080":  false, // internal docker service name
+		"http://localhost:8080":    false,
+		"http://127.0.0.1:8080":    false,
+		"http://10.0.0.5:8080":     false, // private IP
+		"http://192.168.1.10":      false, // private IP
+		"http://core.example.com":  true,  // public FQDN over plaintext
+		"http://8.8.8.8:8080":      true,  // public IP over plaintext
+	} {
+		assert.Equal(t, want, insecureExternalURL(in), in)
+	}
+}
+
 func TestDeriveAction(t *testing.T) {
 	assert.Equal(t, "Created slot", deriveAction("POST", "/api/course_phase/:id/slots"))
 	assert.Equal(t, "Updated participation", deriveAction("PATCH", "/api/.../participations"))

--- a/audit/middleware_test.go
+++ b/audit/middleware_test.go
@@ -196,6 +196,37 @@ func TestRecord_StillWritesWhenSuppressed(t *testing.T) {
 	assert.Equal(t, "Did the thing on purpose", events[0].Action)
 }
 
+func TestMiddleware_CapturesDenialFromAbortingMiddleware(t *testing.T) {
+	sink, wg := newWaitSink(1)
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Middleware(sink, WithActorExtractor(staticActor), WithSourceService("core")))
+	// A downstream authorization middleware that aborts before the handler runs.
+	authz := func(c *gin.Context) { c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "denied"}) }
+	r.POST("/api/course_phase/:coursePhaseID/grades", authz, func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodPost, "/api/course_phase/p1/grades", nil)
+	r.ServeHTTP(httptest.NewRecorder(), req)
+	wg.Wait()
+
+	events := sink.all()
+	require.Len(t, events, 1)
+	assert.Equal(t, OutcomeDenied, events[0].Outcome)
+	assert.Equal(t, "u1", events[0].ActorID)
+}
+
+func TestRecord_SkipsWhenNoActor(t *testing.T) {
+	sink := &fakeSink{}
+	run(t, sink, http.MethodPost, "/api/thing", func(r *gin.Engine) {
+		r.POST("/api/thing", func(c *gin.Context) {
+			c.Set("noActor", true)
+			Record(c, Event{Action: "Orphan event"}) // no actor -> must not write a blank-actor entry
+			c.Status(http.StatusOK)
+		})
+	})
+	assert.Empty(t, sink.all())
+}
+
 func TestMiddleware_NilSinkIsNoOp(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()

--- a/audit/middleware_test.go
+++ b/audit/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -130,7 +131,9 @@ func TestMiddleware_SkipsReadsAndNoise(t *testing.T) {
 		noActor      bool
 	}{
 		{"GET read", http.MethodGet, http.StatusOK, false},
-		{"401 unauth", http.MethodPost, http.StatusUnauthorized, false},
+		// A real unauthenticated 401 has no resolvable actor, so it is skipped;
+		// the actor gate is what filters token-invalid noise from genuine denials.
+		{"401 unauth", http.MethodPost, http.StatusUnauthorized, true},
 		{"404 not found", http.MethodPost, http.StatusNotFound, false},
 		{"422 validation", http.MethodPost, http.StatusUnprocessableEntity, false},
 		{"no actor", http.MethodPost, http.StatusCreated, true},
@@ -146,6 +149,70 @@ func TestMiddleware_SkipsReadsAndNoise(t *testing.T) {
 			assert.Empty(t, sink.all())
 		})
 	}
+}
+
+func TestMiddleware_Logs401DenialWithActor(t *testing.T) {
+	// The SDK auth middleware aborts authorization denials with 401 (not 403);
+	// a 401 that still has a resolvable actor is a genuine denied attempt.
+	sink, wg := newWaitSink(1)
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Middleware(sink, WithActorExtractor(staticActor), WithSourceService("core")))
+	authz := func(c *gin.Context) { c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "denied"}) }
+	r.POST("/api/course_phase/:coursePhaseID/grades", authz, func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/api/course_phase/p1/grades", nil))
+	waitOrFail(t, wg)
+
+	events := sink.all()
+	require.Len(t, events, 1)
+	assert.Equal(t, OutcomeDenied, events[0].Outcome)
+	assert.Equal(t, "u1", events[0].ActorID)
+}
+
+func TestRecord_UsesDescribeLabelWhenActionBlank(t *testing.T) {
+	sink, wg := newWaitSink(1)
+	run(t, sink, http.MethodPost, "/api/courses/c1/publish", func(r *gin.Engine) {
+		r.POST("/api/courses/:courseId/publish", Describe("Published grades"), func(c *gin.Context) {
+			Record(c, Event{EntityType: "grade", EntityID: "g1"}) // no Action
+			c.Status(http.StatusOK)
+		})
+	})
+	waitOrFail(t, wg)
+
+	events := sink.all()
+	require.Len(t, events, 1)
+	assert.Equal(t, "Published grades", events[0].Action) // Describe label, not blank
+}
+
+func TestRecord_StampsRealStatusAndErrorOutcome(t *testing.T) {
+	// "record, then do the work" where the work then fails: the buffered event
+	// must carry the real 500 status and an error outcome, not a premature success.
+	sink, wg := newWaitSink(1)
+	run(t, sink, http.MethodPost, "/api/grades", func(r *gin.Engine) {
+		r.POST("/api/grades", func(c *gin.Context) {
+			Record(c, Event{Action: "Published grades"})
+			c.Status(http.StatusInternalServerError)
+		})
+	})
+	waitOrFail(t, wg)
+
+	events := sink.all()
+	require.Len(t, events, 1)
+	assert.Equal(t, OutcomeError, events[0].Outcome)
+	assert.Equal(t, http.StatusInternalServerError, events[0].HTTPStatus)
+}
+
+func TestPrimaryRole_MatchesCoursePrefixedRoles(t *testing.T) {
+	// Course roles arrive course-prefixed and must match by suffix; platform
+	// roles match exactly and win over course roles.
+	assert.Equal(t, "Lecturer", primaryRole(map[string]bool{"ios24-Lecturer": true}))
+	assert.Equal(t, "Editor", primaryRole(map[string]bool{"ios24-Editor": true}))
+	assert.Equal(t, "PROMPT_Admin", primaryRole(map[string]bool{"PROMPT_Admin": true, "ios24-Lecturer": true}))
+	// PROMPT_Lecturer must not be misread as a course Lecturer by the suffix match.
+	assert.Equal(t, "PROMPT_Lecturer", primaryRole(map[string]bool{"PROMPT_Lecturer": true}))
+	// Unknown roles fall back deterministically to the smallest.
+	assert.Equal(t, "aaa", primaryRole(map[string]bool{"zzz": true, "aaa": true}))
 }
 
 func TestMiddleware_DescribeOverridesLabel(t *testing.T) {
@@ -292,6 +359,50 @@ func TestNewCoreSink_SendsHeaders(t *testing.T) {
 	assert.Equal(t, "secret", gotToken)
 }
 
+func TestNewCoreSink_JoinsPathWithoutDoubleSlash(t *testing.T) {
+	t.Setenv("AUDIT_ENABLED", "true")
+	t.Setenv("AUDIT_INGEST_KEY", "secret")
+	s, ok := NewCoreSink("http://core:8080/", "interview").(*coreSink)
+	require.True(t, ok)
+	assert.Equal(t, "http://core:8080/api/audit", s.url) // trailing slash collapsed
+}
+
+func TestCoreSink_RetryPolicy(t *testing.T) {
+	t.Setenv("AUDIT_ENABLED", "true")
+	t.Setenv("AUDIT_INGEST_KEY", "secret")
+	for _, tc := range []struct {
+		name         string
+		status       int
+		wantAttempts int32
+		wantErr      bool
+	}{
+		{"2xx succeeds", http.StatusNoContent, 1, false},
+		{"4xx fails fast", http.StatusUnauthorized, 1, true},
+		{"3xx is not success and fails fast", http.StatusFound, 1, true},
+		{"5xx retries", http.StatusInternalServerError, 3, true},
+		{"429 retries", http.StatusTooManyRequests, 3, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var attempts int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&attempts, 1)
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			sink := NewCoreSink(srv.URL, "interview")
+			require.NotNil(t, sink)
+			err := sink.Record(context.Background(), Event{Action: "x"})
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantAttempts, atomic.LoadInt32(&attempts))
+		})
+	}
+}
+
 func TestInsecureExternalURL(t *testing.T) {
 	for in, want := range map[string]bool{
 		"https://core.example.com": false, // TLS
@@ -302,6 +413,8 @@ func TestInsecureExternalURL(t *testing.T) {
 		"http://192.168.1.10":      false, // private IP
 		"http://core.example.com":  true,  // public FQDN over plaintext
 		"http://8.8.8.8:8080":      true,  // public IP over plaintext
+		"server-core:8080":         true,  // scheme-less: parses with no host, warn
+		"":                         true,  // empty: malformed config, warn
 	} {
 		assert.Equal(t, want, insecureExternalURL(in), in)
 	}
@@ -311,4 +424,18 @@ func TestDeriveAction(t *testing.T) {
 	assert.Equal(t, "Created slot", deriveAction("POST", "/api/course_phase/:id/slots"))
 	assert.Equal(t, "Updated participation", deriveAction("PATCH", "/api/.../participations"))
 	assert.Equal(t, "Deleted team", deriveAction("DELETE", "/api/teams/:uuid"))
+}
+
+func TestSingularize(t *testing.T) {
+	for in, want := range map[string]string{
+		"slots":          "slot",
+		"teams":          "team",
+		"participations": "participation",
+		"status":         "status",   // -us: keep
+		"campus":         "campus",   // -us: keep
+		"analysis":       "analysis", // -is: keep
+		"class":          "class",    // -ss: keep
+	} {
+		assert.Equal(t, want, singularize(in), in)
+	}
 }

--- a/audit/sink_http.go
+++ b/audit/sink_http.go
@@ -68,7 +68,7 @@ func (s *coreSink) Record(ctx context.Context, e Event) error {
 			lastErr = err
 			continue
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if resp.StatusCode < 300 {
 			return nil
 		}

--- a/audit/sink_http.go
+++ b/audit/sink_http.go
@@ -1,0 +1,78 @@
+package audit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prompt-edu/prompt-sdk/utils"
+)
+
+// coreSink ships audit events from a phase service to the core ingest endpoint,
+// authenticated with the phase's own shared secret.
+type coreSink struct {
+	url     string // full ingest URL, e.g. https://core/api/audit
+	service string // this service's name, sent as X-Audit-Service
+	key     string // this service's shared secret
+	client  *http.Client
+}
+
+// NewCoreSink builds the HTTP sink used by phase services to report audit
+// events to core. It is authenticated with a per-service shared secret read
+// from AUDIT_INGEST_KEY (no Keycloak on the ingest path). It returns nil — which
+// makes Middleware a no-op — when auditing is disabled or no key is configured,
+// so callers can wire it in unconditionally.
+func NewCoreSink(coreURL, serviceName string) Sink {
+	if !Enabled() {
+		return nil
+	}
+	key := utils.GetEnv("AUDIT_INGEST_KEY", "")
+	if key == "" {
+		return nil
+	}
+	return &coreSink{
+		url:     coreURL + "/api/audit",
+		service: serviceName,
+		key:     key,
+		client:  &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// Record posts the event to core with limited retries. It is invoked from a
+// background goroutine by the middleware, so blocking here does not affect the
+// user request.
+func (s *coreSink) Record(ctx context.Context, e Event) error {
+	body, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("failed to marshal audit event: %w", err)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * 500 * time.Millisecond)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("failed to build audit request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Audit-Service", s.service)
+		req.Header.Set("X-Audit-Token", s.key)
+
+		resp, err := s.client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		resp.Body.Close()
+		if resp.StatusCode < 300 {
+			return nil
+		}
+		lastErr = fmt.Errorf("audit ingest returned status %d", resp.StatusCode)
+	}
+	return lastErr
+}

--- a/audit/sink_http.go
+++ b/audit/sink_http.go
@@ -5,8 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/prompt-edu/prompt-sdk/utils"
 )
@@ -33,12 +38,35 @@ func NewCoreSink(coreURL, serviceName string) Sink {
 	if key == "" {
 		return nil
 	}
+	if insecureExternalURL(coreURL) {
+		log.Warnf("audit: ingest URL %q sends the shared secret and event payload over plaintext HTTP to a non-internal host; "+
+			"use HTTPS or keep phase->core traffic on an internal network", coreURL)
+	}
 	return &coreSink{
 		url:     coreURL + "/api/audit",
 		service: serviceName,
 		key:     key,
 		client:  &http.Client{Timeout: 10 * time.Second},
 	}
+}
+
+// insecureExternalURL reports whether raw sends data unencrypted (plain HTTP) to
+// a host that is not clearly internal. Loopback, private IPs, and short service
+// names (docker/k8s, e.g. "server-core") are treated as internal/trusted and do
+// not warn; a dotted public hostname or public IP over HTTP does.
+func insecureExternalURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "https" {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" || host == "localhost" || !strings.Contains(host, ".") {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return !ip.IsLoopback() && !ip.IsPrivate()
+	}
+	return true
 }
 
 // Record posts the event to core with limited retries. It is invoked from a

--- a/audit/sink_http.go
+++ b/audit/sink_http.go
@@ -42,8 +42,16 @@ func NewCoreSink(coreURL, serviceName string) Sink {
 		log.Warnf("audit: ingest URL %q sends the shared secret and event payload over plaintext HTTP to a non-internal host; "+
 			"use HTTPS or keep phase->core traffic on an internal network", coreURL)
 	}
+	// url.JoinPath normalizes separators, so a coreURL with (or without) a
+	// trailing slash still yields ".../api/audit" rather than "...//api/audit",
+	// which gin would 404 at runtime.
+	ingestURL, err := url.JoinPath(coreURL, "api", "audit")
+	if err != nil {
+		log.Warnf("audit: invalid core URL %q: %v; audit reporting disabled for this service", coreURL, err)
+		return nil
+	}
 	return &coreSink{
-		url:     coreURL + "/api/audit",
+		url:     ingestURL,
 		service: serviceName,
 		key:     key,
 		client:  &http.Client{Timeout: 10 * time.Second},
@@ -56,12 +64,18 @@ func NewCoreSink(coreURL, serviceName string) Sink {
 // not warn; a dotted public hostname or public IP over HTTP does.
 func insecureExternalURL(raw string) bool {
 	u, err := url.Parse(raw)
-	if err != nil || u.Scheme == "https" {
+	if err != nil {
+		return true // unparseable: warn rather than silently accept a bad config
+	}
+	if u.Scheme == "https" {
 		return false
 	}
 	host := u.Hostname()
-	if host == "" || host == "localhost" || !strings.Contains(host, ".") {
-		return false
+	if host == "" {
+		return true // e.g. a scheme-less "server-core:8080" — malformed, warn
+	}
+	if host == "localhost" || !strings.Contains(host, ".") {
+		return false // loopback or a short service name (docker/k8s)
 	}
 	if ip := net.ParseIP(host); ip != nil {
 		return !ip.IsLoopback() && !ip.IsPrivate()
@@ -94,13 +108,20 @@ func (s *coreSink) Record(ctx context.Context, e Event) error {
 		resp, err := s.client.Do(req)
 		if err != nil {
 			lastErr = err
-			continue
+			continue // network error: worth retrying
 		}
+		status := resp.StatusCode
 		_ = resp.Body.Close()
-		if resp.StatusCode < 300 {
+		if status >= 200 && status < 300 {
 			return nil
 		}
-		lastErr = fmt.Errorf("audit ingest returned status %d", resp.StatusCode)
+		lastErr = fmt.Errorf("audit ingest returned status %d", status)
+		// Only transient failures are worth retrying. A 4xx (e.g. 401 from a key
+		// mismatch, or 400 from a malformed event) fails identically every time,
+		// so retrying it just burns the delivery slots that other events need.
+		if status != http.StatusTooManyRequests && status < 500 {
+			return lastErr
+		}
 	}
 	return lastErr
 }

--- a/promptTypes/serviceInfo.go
+++ b/promptTypes/serviceInfo.go
@@ -29,6 +29,11 @@ const (
 	// associated with a subject on GDPR deletion request.
 	// Expected endpoint: POST .../privacy/data-deletion
 	CapabilityPrivacyDeletion = "privacy.deletion"
+
+	// CapabilityAuditLog indicates that the service reports audit events to the
+	// central audit log (via the shared audit middleware). Reflects whether the
+	// AUDIT_ENABLED feature toggle is on for the service.
+	CapabilityAuditLog = "audit.log"
 )
 
 // ServiceInfo describes a course phase microservice — its identity, health, and capabilities.


### PR DESCRIPTION
## Summary

Adds a shared `audit` package that provides one unified audit-logging API for the core service and every course phase. Consumed by the core audit-log feature (see the companion PR in `prompt-edu/prompt`).

## Details

- **`Event` + `Sink`** — a neutral audit record and a small consumer-side sink interface (core persists to its DB; phases ship over HTTP).
- **`Middleware`** — auto-captures mutating requests (`POST/PUT/PATCH/DELETE`) that succeed (2xx → `success`) or are denied (403 → `denied`); runs after auth, skips reads/`401`/validation noise and requests with no actor. Actor is read via an injectable extractor (`WithActorExtractor`) so it works both with the SDK `TokenUser` and with core's flat context keys.
- **Developer helpers** — `Describe(label)` (route-scoped label), `Record`/`Suppress`/`Skip` (rich/background events and opt-out; `Record` auto-suppresses the backstop to avoid duplicates), `Enabled()` (feature toggle).
- **`NewCoreSink`** — HTTP sink for phases, authenticated with a per-service shared secret (`X-Audit-Service` + `X-Audit-Token` from `AUDIT_INGEST_KEY`), async best-effort with retries; returns nil (making `Middleware` a no-op) when disabled.
- **`promptTypes.CapabilityAuditLog`** — capability constant so phases report audit state via `GET /info`.

## Reason / Link to issue

Foundation for the centralized audit log. Companion PR: `prompt-edu/prompt` (core store + UI + wiring).

## How to Test

```
go test ./audit/
```

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable audit logging for successful and denied service actions.
  * Captures actor identity, actions, entities, request details, outcomes, and service information.
  * Supports custom action labels, skipped routes, suppressed events, and explicit event recording.
  * Added secure HTTP delivery with retries, timeout handling, and configurable enablement.
  * Added an audit-log capability indicator for service metadata.

* **Tests**
  * Added coverage for audit recording, filtering, configuration, delivery, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->